### PR TITLE
Feature: support 'all' keyword in update commands

### DIFF
--- a/Shelly-CLI/Commands/Standard/UpdateCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpdateCommand.cs
@@ -18,8 +18,16 @@ public class UpdateCommand : Command<PackageSettings>
         }
 
         var packageList = settings.Packages.ToList();
+        bool isUpdateAll = packageList.Any(p => p.Equals("all", StringComparison.OrdinalIgnoreCase));
 
-        AnsiConsole.MarkupLine($"[yellow]Packages to update:[/] {string.Join(", ", packageList)}");
+        if (isUpdateAll)
+        {
+            AnsiConsole.MarkupLine("[yellow]Updating all packages (System Upgrade)...[/]");
+        }
+        else
+        {
+            AnsiConsole.MarkupLine($"[yellow]Packages to update:[/] {string.Join(", ", packageList)}");
+        }
 
         if (!settings.NoConfirm)
         {
@@ -32,16 +40,10 @@ public class UpdateCommand : Command<PackageSettings>
 
         using var manager = new AlpmManager();
 
-        manager.Progress += (sender, args) =>
-        {
-            AnsiConsole.MarkupLine($"[blue]{args.PackageName}[/]: {args.Percent}%");
-        };
-
         manager.Question += (sender, args) =>
         {
             if (settings.NoConfirm)
             {
-                // Machine-readable format for UI integration
                 Console.Error.WriteLine($"[Shelly][ALPM_QUESTION]{args.QuestionText}");
                 Console.Error.Flush();
                 var input = Console.ReadLine();
@@ -54,11 +56,51 @@ public class UpdateCommand : Command<PackageSettings>
             }
         };
 
-        AnsiConsole.MarkupLine("[yellow]Initializing and syncing ALPM...[/]");
-        manager.IntializeWithSync();
+        AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .Start("[yellow]Initializing and syncing ALPM...[/]", ctx =>
+            {
+                manager.IntializeWithSync();
+            });
 
-        AnsiConsole.MarkupLine("[yellow]Updating packages...[/]");
-        manager.UpdatePackages(packageList);
+        AnsiConsole.Progress()
+            .Columns(
+                new TaskDescriptionColumn(),
+                new ProgressBarColumn(),
+                new PercentageColumn(),
+                new RemainingTimeColumn(),
+                new SpinnerColumn()
+            )
+            .Start(ctx =>
+            {
+                var mainTask = ctx.AddTask("[green]Updating packages[/]", maxValue: isUpdateAll ? 100 : packageList.Count);
+                var detailTask = ctx.AddTask("[blue]Waiting...[/]", maxValue: 100);
+
+                manager.Progress += (sender, args) =>
+                {
+                    if (args.HowMany.HasValue && args.HowMany.Value > 0)
+                    {
+                        mainTask.MaxValue = (double)args.HowMany.Value;
+                        mainTask.Value = (double)args.Current.GetValueOrDefault();
+                    }
+                    
+                    detailTask.Description = $"[cyan]{args.PackageName ?? "Processing"}[/]";
+                    detailTask.Value = args.Percent.GetValueOrDefault();
+                };
+
+                if (isUpdateAll)
+                {
+                    manager.UpdateAll();
+                }
+                else
+                {
+                    manager.UpdatePackages(packageList);
+                }
+                
+                mainTask.Value = mainTask.MaxValue;
+                detailTask.Value = 100;
+                detailTask.Description = "[green]Done[/]";
+            });
 
         AnsiConsole.MarkupLine("[green]Packages updated successfully![/]");
         return 0;


### PR DESCRIPTION
Allows users to run 'shelly update all' and 'shelly aur update all' to perform a full system upgrade of standard and AUR packages respectively.