### PR TITLE
Add cascade and config removal options to `RemoveCommand`

### DIFF
--- a/Shelly-CLI/Commands/Standard/RemovePackageSettings.cs
+++ b/Shelly-CLI/Commands/Standard/RemovePackageSettings.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Shelly_CLI.Commands.Standard;
+
+public class RemovePackageSettings : PackageSettings
+{
+    [CommandOption("-c | --cascade")]
+    [Description("Removes all things the removed package(s) are dependent on that have no other uses")]
+    public bool Cascade { get; set; }
+
+    [CommandOption("-r | --remove-config")]
+    [Description("Removes any files in your ~/.config that can be tied exclusively to the removed package(s). This is EXPERIMENTAL and has no guarantees of working")]
+    public bool RemoveConfig { get; set; }
+}

--- a/Shelly-CLI/rd.xml
+++ b/Shelly-CLI/rd.xml
@@ -22,6 +22,7 @@
             <Type Name="Shelly_CLI.Commands.Standard.InstallLocalPackageCommand" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.InstallLocalPackageSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.RemoveCommand" Dynamic="Required All"/>
+            <Type Name="Shelly_CLI.Commands.Standard.RemovePackageSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.UpdateCommand" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.UpgradeSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.UpgradeCommand" Dynamic="Required All"/>


### PR DESCRIPTION
- Introduced `RemovePackageSettings` to handle new options.
- Added `--cascade` for removing package dependencies with no other uses.
- Added `--remove-config` to delete config files tied exclusively to removed packages (experimental).
- Updated `RemoveCommand` execution logic to support these features.