### PR TITLE
Add `ArchNews` execution to `UpgradeCommand` and update rd.xml

### DIFF
--- a/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
@@ -19,6 +19,9 @@ public class UpgradeCommand : Command<UpgradeSettings>
             return HandleUiModeUpgrade(settings);
         }
         
+        var archNews = new ArchNews();
+        archNews.ExecuteAsync(context, new ArchNewsSettings()).GetAwaiter().GetResult();
+        
         AnsiConsole.MarkupLine("[yellow]Performing full system upgrade...[/]");
 
         var manager = new AlpmManager();

--- a/Shelly-CLI/rd.xml
+++ b/Shelly-CLI/rd.xml
@@ -26,6 +26,8 @@
             <Type Name="Shelly_CLI.Commands.Standard.UpdateCommand" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.UpgradeSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.UpgradeCommand" Dynamic="Required All"/>
+            <Type Name="Shelly_CLI.Commands.Standard.ArchNews" Dynamic="Required All"/>
+            <Type Name="Shelly_CLI.Commands.Standard.ArchNewsSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.DowngradePackageCommand" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.DowngradePackageCommandSettings" Dynamic="Required All"/>
             <!-- Keyring commands -->


### PR DESCRIPTION
- Integrated `ArchNews` and `ArchNewsSettings` to the runtime directives file.
- Added `ArchNews` execution before the system upgrade process in `UpgradeCommand`.