### PR TITLE
Adding a manpage for Shelly-CLI

### DIFF
--- a/Man/shelly.1
+++ b/Man/shelly.1
@@ -8,11 +8,10 @@ shelly \- command-line libalpm utility
 .RI [ OPTIONS ] " <COMMAND>"
 
 .SH DESCRIPTION
-Shelly is a comand-line interface for managing system packages,
-syncronizing databases, and performing system maintenance tasks. 
-It provides functionality similar to traditional package managers 
+Shelly is a command-line interface for managing system packages,
+synchronizing databases, and performing system maintenance tasks.
+It provides functionality similar to traditional package managers
 with extended support for AUR and Flatpak.
-
 
 .\" After this point, there should be information on every command available to shelly.
 


### PR DESCRIPTION
This PR adds a manpage for Shelly-CLI. It includes a combination of all the documentation present in the -h/-help tool that is already included within Shelly-CLI itself, but presented as a manpage. 

Note that this doesn't mean the manpage is already included in Path, it just means there is now a file that contains the basic information required for the manpage to function.

If any changes in wording and/or description are necessary, or any expansions to descriptions when it comes to what each command does, please point out what should be changed and I'll make the necessary adjustments. 