### PR TITLE
Add "Comment" field to Shelly desktop entry

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -63,6 +63,7 @@ package() {
   cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/shelly.desktop"
 [Desktop Entry]
 Name=Shelly
+Comment=A Modern Arch Package Manager
 Exec=/usr/bin/shelly-ui
 Icon=shelly
 Type=Application

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ echo "Creating desktop entry"
 cat <<EOF > /usr/share/applications/shelly.desktop
 [Desktop Entry]
 Name=Shelly
+Comment=A Modern Arch Package Manager
 Exec=/usr/bin/shelly-ui
 Icon=shelly
 Type=Application

--- a/local-install.sh
+++ b/local-install.sh
@@ -83,6 +83,7 @@ echo "Creating desktop entry"
 cat <<EOF > /usr/share/applications/shelly.desktop
 [Desktop Entry]
 Name=Shelly
+Comment=A Modern Arch Package Manager
 Exec=/opt/bin/shelly-ui
 Icon=shelly
 Type=Application

--- a/web-install.sh
+++ b/web-install.sh
@@ -92,6 +92,7 @@ echo "Creating desktop entry"
 cat <<EOF > /usr/share/applications/shelly.desktop
 [Desktop Entry]
 Name=Shelly
+Comment=A Modern Arch Package Manager
 Exec=/usr/bin/shelly-ui
 Icon=shelly
 Type=Application


### PR DESCRIPTION
This pull request adds a "Comment" field to the desktop entry for the Shelly application across all installers, ensuring consistency and improved descriptions in desktop environments.