### PR TITLE
Disable action buttons in package management windows when no items ar…

### DIFF
--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -40,6 +40,7 @@ public class AurInstall(
     private ColumnViewColumn _votesColumn = null!;
     private ColumnViewColumn _popColumn = null!;
     private ColumnViewColumn _versionColumn = null!;
+    private Button _installButton = null!;
 
     public Widget CreateWindow()
     {
@@ -62,8 +63,8 @@ public class AurInstall(
 
         _versionColumn = (ColumnViewColumn)builder.GetObject("version_column")!;
         _versionColumn.Resizable = true;
-        var installButton = (Button)builder.GetObject("install_button")!;
-
+        _installButton = (Button)builder.GetObject("install_button")!;
+        _installButton.SetSensitive(false);
         _listStore = Gio.ListStore.New(AurPackageGObject.GetGType());
         _selectionModel = SingleSelection.New(_listStore);
         _selectionModel.CanUnselect = true;
@@ -81,9 +82,10 @@ public class AurInstall(
             if (item is AurPackageGObject pkgObj)
             {
                 pkgObj.ToggleSelection();
+                _installButton.SetSensitive(AnySelected());
             }
         };
-        installButton.OnClicked += (_, _) => { _ = InstallSelectedAsync(); };
+        _installButton.OnClicked += (_, _) => { _ = InstallSelectedAsync(); };
         _searchEntry.OnActivate += (_, _) => { _ = SearchAsync(_cts.Token); };
 
         return _box;
@@ -434,6 +436,18 @@ public class AurInstall(
         }
 
         return $"{DateTime.Now:yyyyMMddHHmmss}_aur-install_{packageName}.log";
+    }
+
+    private bool AnySelected()
+    {
+        for (uint i = 0; i < _listStore.GetNItems(); i++)
+        {
+            var item = _listStore.GetObject(i);
+            if (item is AurUpdateGObject { IsSelected: true })
+                return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/Shelly.Gtk/Windows/AUR/AurRemove.cs
+++ b/Shelly.Gtk/Windows/AUR/AurRemove.cs
@@ -4,11 +4,16 @@ using Shelly.Gtk.Helpers;
 using Shelly.Gtk.Services;
 using Shelly.Gtk.UiModels;
 using Shelly.Gtk.UiModels.AUR.GObjects;
+
 // ReSharper disable CollectionNeverQueried.Local
 
 namespace Shelly.Gtk.Windows.AUR;
 
-public class AurRemove(IPrivilegedOperationService privilegedOperationService, ILockoutService lockoutService, IConfigService configService, IGenericQuestionService genericQuestionService)
+public class AurRemove(
+    IPrivilegedOperationService privilegedOperationService,
+    ILockoutService lockoutService,
+    IConfigService configService,
+    IGenericQuestionService genericQuestionService)
     : IShellyWindow
 {
     private Box _box = null!;
@@ -22,12 +27,16 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
     private SignalListItemFactory _checkFactory = null!;
     private SignalListItemFactory _nameFactory = null!;
     private SignalListItemFactory _versionFactory = null!;
-    private Dictionary<ColumnViewCell, (SignalHandler<CheckButton> OnToggled, EventHandler OnExternalToggle)> _checkBinding = [];
+
+    private Dictionary<ColumnViewCell, (SignalHandler<CheckButton> OnToggled, EventHandler OnExternalToggle)>
+        _checkBinding = [];
+
     private readonly List<AurPackageGObject> _packageGObjectRefs = [];
     private ColumnViewColumn _checkColumn = null!;
     private ColumnViewColumn _nameColumn = null!;
     private ColumnViewColumn _versionColumn = null!;
-   
+    private Button _removeButton = null!;
+
 
     public Widget CreateWindow()
     {
@@ -39,8 +48,8 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
         _checkColumn = (ColumnViewColumn)builder.GetObject("check_column")!;
         _nameColumn = (ColumnViewColumn)builder.GetObject("name_column")!;
         _versionColumn = (ColumnViewColumn)builder.GetObject("version_column")!;
-        var removeButton = (Button)builder.GetObject("remove_button")!;
-
+        _removeButton = (Button)builder.GetObject("remove_button")!;
+        _removeButton.SetSensitive(false);
         _listStore = Gio.ListStore.New(AurPackageGObject.GetGType());
         _filter = CustomFilter.New(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
@@ -51,7 +60,7 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
         SetupColumns(_checkColumn, _nameColumn, _versionColumn);
 
         ColumnViewHelper.AlignColumnHeader(_columnView, 1, Align.End);
-        
+
         _columnView.OnRealize += (_, _) => { _ = LoadDataAsync(_cts.Token); };
         _columnView.OnActivate += (_, _) =>
         {
@@ -66,8 +75,8 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
             _searchText = searchEntry.GetText();
             ApplyFilter();
         };
-        removeButton.OnClicked += (_, _) => { _ = RemovePackagesAsync(); };
-        
+        _removeButton.OnClicked += (_, _) => { _ = RemovePackagesAsync(); };
+
         return _box;
     }
 
@@ -76,14 +85,15 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
         if (obj is not AurPackageGObject pkgObj || pkgObj.Package == null)
             return false;
 
-        return string.IsNullOrWhiteSpace(_searchText) || pkgObj.Package.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+        return string.IsNullOrWhiteSpace(_searchText) ||
+               pkgObj.Package.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase);
     }
-    
+
     private void ApplyFilter()
     {
         _filter.Changed(FilterChange.Different);
     }
-    
+
     private void SetupColumns(ColumnViewColumn checkColumn, ColumnViewColumn nameColumn, ColumnViewColumn versionColumn)
     {
         var checkFactory = _checkFactory = SignalListItemFactory.New();
@@ -111,6 +121,7 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
             void OnToggled(CheckButton s, EventArgs e)
             {
                 pkgObj.IsSelected = s.GetActive();
+                _removeButton.SetSensitive(AnySelected());
             }
 
             void OnExternalToggle(object? s, EventArgs e)
@@ -125,7 +136,8 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
         checkFactory.OnUnbind += (_, args) =>
         {
             if (args.Object is not ColumnViewCell listItem) return;
-            if (listItem.GetItem() is not AurPackageGObject pkgObj || listItem.GetChild() is not CheckButton checkButton) return;
+            if (listItem.GetItem() is not AurPackageGObject pkgObj ||
+                listItem.GetChild() is not CheckButton checkButton) return;
             if (_checkBinding.Remove(listItem, out var handlers))
             {
                 pkgObj.OnSelectionToggled -= handlers.OnExternalToggle;
@@ -134,7 +146,7 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
         };
 
         checkColumn.SetFactory(checkFactory);
-        
+
         var nameFactory = _nameFactory = SignalListItemFactory.New();
         nameFactory.OnSetup += (_, args) =>
         {
@@ -151,7 +163,7 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
             label.Halign = Align.Start;
         };
         nameColumn.SetFactory(nameFactory);
-        
+
         var versionFactory = _versionFactory = SignalListItemFactory.New();
         versionFactory.OnSetup += (_, args) =>
         {
@@ -169,6 +181,7 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
         };
         versionColumn.SetFactory(versionFactory);
     }
+
     private async Task LoadDataAsync(CancellationToken ct = default)
     {
         try
@@ -226,11 +239,11 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
                     return;
                 }
             }
-            
+
             try
             {
                 lockoutService.Show($"Installing...");
-                
+
                 try
                 {
                     //do work
@@ -245,7 +258,7 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
                 finally
                 {
                     lockoutService.Hide();
-                    
+
                     var args = new ToastMessageEventArgs(
                         $"Updated {selectedPackages.Count} Package(s)"
                     );
@@ -257,6 +270,18 @@ public class AurRemove(IPrivilegedOperationService privilegedOperationService, I
                 Console.WriteLine($"Failed to remove packages: {e.Message}");
             }
         }
+    }
+
+    private bool AnySelected()
+    {
+        for (uint i = 0; i < _listStore.GetNItems(); i++)
+        {
+            var item = _listStore.GetObject(i);
+            if (item is AurUpdateGObject { IsSelected: true })
+                return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/Shelly.Gtk/Windows/AUR/AurUpdate.cs
+++ b/Shelly.Gtk/Windows/AUR/AurUpdate.cs
@@ -53,6 +53,7 @@ public class AurUpdate(
         _versionColumn.Resizable = true;
 
         _updateButton = (Button)builder.GetObject("update_button")!;
+        _updateButton.SetSensitive(false);
 
         _listStore = Gio.ListStore.New(AurUpdateGObject.GetGType());
         _filter = CustomFilter.New(FilterPackage);
@@ -125,6 +126,7 @@ public class AurUpdate(
             void OnToggled(CheckButton s, EventArgs e)
             {
                 pkgObj.IsSelected = s.GetActive();
+                _updateButton.SetSensitive(AnySelected());
             }
 
             void OnExternalToggle(object? s, EventArgs e)
@@ -292,6 +294,18 @@ public class AurUpdate(
                 Console.WriteLine($"Failed to remove packages: {e.Message}");
             }
         }
+    }
+
+    private bool AnySelected()
+    {
+        for (uint i = 0; i < _listStore.GetNItems(); i++)
+        {
+            var item = _listStore.GetObject(i);
+            if (item is AurUpdateGObject { IsSelected: true })
+                return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/Shelly.Gtk/Windows/MetaSearch.cs
+++ b/Shelly.Gtk/Windows/MetaSearch.cs
@@ -5,6 +5,7 @@ using Shelly.Gtk.Services;
 using Shelly.Gtk.UiModels;
 using Shelly.Gtk.UiModels.PackageManagerObjects.GObjects;
 using Shelly.Gtk.Windows.Dialog;
+
 // ReSharper disable CollectionNeverQueried.Local
 
 namespace Shelly.Gtk.Windows;
@@ -48,6 +49,7 @@ public class MetaSearch(
         _box = (Box)builder.GetObject("MetaSearchWindow")!;
         _columnView = (ColumnView)builder.GetObject("package_grid")!;
         _installButton = (Button)builder.GetObject("install_button")!;
+        _installButton.SetSensitive(false);
 
         _checkColumn = (ColumnViewColumn)builder.GetObject("check_column")!;
         _nameColumn = (ColumnViewColumn)builder.GetObject("name_column")!;
@@ -96,6 +98,7 @@ public class MetaSearch(
             {
                 if (listItem.GetItem() is MetaPackageGObject pkgObj)
                     pkgObj.IsSelected = s.GetActive();
+                _installButton.SetSensitive(AnySelected());
             };
         };
         _checkFactory.OnBind += (_, args) =>
@@ -173,7 +176,8 @@ public class MetaSearch(
         {
             if (args.Object is not ColumnViewCell listItem) return;
             if (listItem.GetItem() is MetaPackageGObject { Package: { } pkg } && listItem.GetChild() is Label label)
-                label.SetText(pkg.Description.Substring(0, pkg.Description.Length > 100 ? 100 : pkg.Description.Length));
+                label.SetText(pkg.Description.Substring(0,
+                    pkg.Description.Length > 100 ? 100 : pkg.Description.Length));
         };
         descriptionColumn.SetFactory(_descriptionFactory);
     }
@@ -295,7 +299,7 @@ public class MetaSearch(
                 {
                     //TODO: This evnetually needs to work with everything else but this page only works with flathub atm
                     //This can be a future improvment we can make on this page...
-                   await unprivilegedOperationService.InstallFlatpakPackage(pkg,false,"flathub","stable");
+                    await unprivilegedOperationService.InstallFlatpakPackage(pkg, false, "flathub", "stable");
                 }
             }
         }
@@ -306,12 +310,24 @@ public class MetaSearch(
         finally
         {
             lockoutService.Hide();
-                
+
             var args = new ToastMessageEventArgs(
                 $"Updated {selected.Count} Package(s)"
             );
             genericQuestionService.RaiseToastMessage(args);
         }
+    }
+
+    private bool AnySelected()
+    {
+        for (uint i = 0; i < _listStore.GetNItems(); i++)
+        {
+            var item = _listStore.GetObject(i);
+            if (item is MetaPackageGObject { IsSelected: true })
+                return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -75,6 +75,7 @@ public class PackageInstall(
         _repositoryColumn = (ColumnViewColumn)_builder.GetObject("repository_column")!;
         _repositoryColumn.Resizable = true;
         _installButton = (Button)_builder.GetObject("install_button")!;
+        _installButton.SetSensitive(false);
         _localInstallButton = (Button)_builder.GetObject("install_local_button")!;
         _appImageButton = (Button)_builder.GetObject("install_appimage_button")!;
         _searchEntry = (SearchEntry)_builder.GetObject("search_entry")!;
@@ -258,6 +259,7 @@ public class PackageInstall(
             void OnToggled(CheckButton s, EventArgs e)
             {
                 pkgObj.IsSelected = s.GetActive();
+                _installButton.SetSensitive(AnySelected());
             }
 
             void OnExternalToggle(object? s, EventArgs e)
@@ -596,6 +598,18 @@ public class PackageInstall(
         }
     }
 
+    private bool AnySelected()
+    {
+        for (uint i = 0; i < _listStore.GetNItems(); i++)
+        {
+            var item = _listStore.GetObject(i);
+            if (item is AlpmPackageGObject { IsSelected: true })
+                return true;
+        }
+
+        return false;
+    }
+    
     public void Dispose()
     {
         _cts.Cancel();

--- a/Shelly.Gtk/Windows/Packages/PackageManagement.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageManagement.cs
@@ -70,6 +70,7 @@ public class PackageManagement(
 
         _refreshButton = (Button)builder.GetObject("sync_button")!;
         _removeButton = (Button)builder.GetObject("remove_button")!;
+        _removeButton.SetSensitive(false);
 
         _listStore = Gio.ListStore.New(AlpmPackageGObject.GetGType());
         _filter = CustomFilter.New(FilterPackage);
@@ -143,6 +144,7 @@ public class PackageManagement(
             void OnToggled(CheckButton s, EventArgs e)
             {
                 pkgObj.IsSelected = s.GetActive();
+                _removeButton.SetSensitive(AnySelected());
             }
 
             void OnExternalToggle(object? s, EventArgs e)
@@ -323,6 +325,18 @@ public class PackageManagement(
                 genericQuestionService.RaiseToastMessage(args);
             }
         }
+    }
+
+    private bool AnySelected()
+    {
+        for (uint i = 0; i < _listStore.GetNItems(); i++)
+        {
+            var item = _listStore.GetObject(i);
+            if (item is AlpmPackageGObject { IsSelected: true })
+                return true;
+        }
+
+        return false;
     }
 
     public void Dispose()


### PR DESCRIPTION
…e selected

- Set button sensitivity for `install`, `update`, and `remove` actions based on item selection across various windows.
- Added `AnySelected()` helper method to determine selection state in list stores.
- Updated button initialization to ensure they are disabled by default.