### PR TITLE
Add `RootElevator` to enforce root privileges across commands

### DIFF
--- a/Shelly-CLI/Commands/Aur/AurInstallCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurInstallCommand.cs
@@ -12,13 +12,14 @@ namespace Shelly_CLI.Commands.Aur;
 
 public class AurInstallCommand : AsyncCommand<AurInstallSettings>
 {
-    public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] AurInstallSettings settings)
+    public override async Task<int> ExecuteAsync([NotNull] CommandContext context,
+        [NotNull] AurInstallSettings settings)
     {
         if (Program.IsUiMode)
         {
             return await HandleUiModeInstall(settings);
         }
-        
+
         AurPackageManager? manager = null;
         if (settings.Packages.Length == 0)
         {
@@ -41,6 +42,7 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
 
         try
         {
+            RootElevator.EnsureRootExectuion();
             manager = new AurPackageManager();
             await manager.Initialize(root: true);
             object renderLock = new();
@@ -71,10 +73,10 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
                 {
                     AnsiConsole.WriteLine();
                     // Handle SelectProvider and ConflictPkg differently - they need a selection, not yes/no
-                    QuestionHandler.HandleQuestion(args,Program.IsUiMode,settings.NoConfirm);
+                    QuestionHandler.HandleQuestion(args, Program.IsUiMode, settings.NoConfirm);
                 }
             };
-            
+
 
             if (settings.BuildDepsOn)
             {
@@ -146,7 +148,7 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
 
             AnsiConsole.MarkupLine("[green]Installation complete.[/]");
 
-           return 0;
+            return 0;
         }
         catch (Exception ex)
         {
@@ -179,20 +181,14 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
             manager.PackageProgress += (sender, args) =>
             {
                 Console.Error.WriteLine($"[{args.CurrentIndex}/{args.TotalCount}] {args.PackageName}: {args.Status}" +
-                    (args.Message != null ? $" - {args.Message}" : ""));
+                                        (args.Message != null ? $" - {args.Message}" : ""));
             };
 
             // Handle progress events
-            manager.Progress += (sender, args) =>
-            {
-                Console.Error.WriteLine($"{args.PackageName}: {args.Percent}%");
-            };
+            manager.Progress += (sender, args) => { Console.Error.WriteLine($"{args.PackageName}: {args.Percent}%"); };
 
             // Handle questions
-            manager.Question += (sender, args) =>
-            {
-                QuestionHandler.HandleQuestion(args, true, settings.NoConfirm);
-            };
+            manager.Question += (sender, args) => { QuestionHandler.HandleQuestion(args, true, settings.NoConfirm); };
 
             // Handle build dependencies only mode
             if (settings.BuildDepsOn)

--- a/Shelly-CLI/Commands/Aur/AurInstallVersionCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurInstallVersionCommand.cs
@@ -15,6 +15,7 @@ public class AurInstallVersionCommand : AsyncCommand<AurInstallVersionSettings>
             return await HandleUiModeInstallVersion(settings);
         }
 
+        RootElevator.EnsureRootExectuion();
         AurPackageManager? manager = null;
         if (string.IsNullOrWhiteSpace(settings.Package))
         {

--- a/Shelly-CLI/Commands/Aur/AurRemoveCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurRemoveCommand.cs
@@ -28,7 +28,7 @@ public class AurRemoveCommand : AsyncCommand<AurPackageSettings>
 
         try
         {
-            
+            RootElevator.EnsureRootExectuion();
             manager = new AurPackageManager();
             await manager.Initialize(root: true);
             object renderLock = new();

--- a/Shelly-CLI/Commands/Aur/AurUpdateCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurUpdateCommand.cs
@@ -23,6 +23,7 @@ public class AurUpdateCommand : AsyncCommand<AurPackageSettings>
             return 1;
         }
 
+        RootElevator.EnsureRootExectuion();
         AurPackageManager? manager = null;
         try
         {

--- a/Shelly-CLI/Commands/Aur/AurUpgradeCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurUpgradeCommand.cs
@@ -18,6 +18,7 @@ public class AurUpgradeCommand : AsyncCommand<AurUpgradeSettings>
         AurPackageManager? manager = null;
         try
         {
+            RootElevator.EnsureRootExectuion();
             manager = new AurPackageManager();
             await manager.Initialize(root: true);
 

--- a/Shelly-CLI/Commands/DefaultCommand.cs
+++ b/Shelly-CLI/Commands/DefaultCommand.cs
@@ -11,7 +11,7 @@ public class DefaultCommand : AsyncCommand
 {
     public override async Task<int> ExecuteAsync(CommandContext context)
     {
-        var username = Environment.GetEnvironmentVariable("SUDO_USER");
+        var username = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;;
         var configPath = Path.Combine("/home", username, ".config", "shelly", "config.json");
         Console.WriteLine(configPath);
         if (!File.Exists(configPath))

--- a/Shelly-CLI/Commands/Keyring/KeyringInitCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringInitCommand.cs
@@ -14,6 +14,7 @@ public class KeyringInitCommand : Command
             return HandleUiModeInit();
         }
 
+        RootElevator.EnsureRootExectuion();
         AnsiConsole.MarkupLine("[yellow]Initializing pacman keyring...[/]");
         var result = PacmanKeyRunner.Run("--init");
         if (result == 0)

--- a/Shelly-CLI/Commands/Keyring/KeyringListCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringListCommand.cs
@@ -14,6 +14,7 @@ public class KeyringListCommand : Command
             return HandleUiModeList();
         }
 
+        RootElevator.EnsureRootExectuion();
         AnsiConsole.MarkupLine("[yellow]Listing keys in keyring...[/]");
         return PacmanKeyRunner.Run("--list-keys");
     }

--- a/Shelly-CLI/Commands/Keyring/KeyringLsignCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringLsignCommand.cs
@@ -14,6 +14,7 @@ public class KeyringLsignCommand : Command<KeyringSettings>
             return HandleUiModeLsign(settings);
         }
 
+        RootElevator.EnsureRootExectuion();
         if (settings.Keys == null || settings.Keys.Length == 0)
         {
             AnsiConsole.MarkupLine("[red]Error: No key IDs specified[/]");

--- a/Shelly-CLI/Commands/Keyring/KeyringPopulateCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringPopulateCommand.cs
@@ -14,6 +14,7 @@ public class KeyringPopulateCommand : Command<KeyringSettings>
             return HandleUiModePopulate(settings);
         }
 
+        RootElevator.EnsureRootExectuion();
         var args = "--populate";
         if (settings.Keys?.Length > 0)
         {

--- a/Shelly-CLI/Commands/Keyring/KeyringRecvCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringRecvCommand.cs
@@ -14,6 +14,7 @@ public class KeyringRecvCommand : Command<KeyringSettings>
             return HandleUiModeRecv(settings);
         }
 
+        RootElevator.EnsureRootExectuion();
         if (settings.Keys == null || settings.Keys.Length == 0)
         {
             AnsiConsole.MarkupLine("[red]Error: No key IDs specified[/]");

--- a/Shelly-CLI/Commands/Keyring/KeyringRefreshCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringRefreshCommand.cs
@@ -14,6 +14,7 @@ public class KeyringRefreshCommand : Command
             return HandleUiModeRefresh();
         }
 
+        RootElevator.EnsureRootExectuion();
         AnsiConsole.MarkupLine("[yellow]Refreshing keys from keyserver...[/]");
         var result = PacmanKeyRunner.Run("--refresh-keys");
         if (result == 0)

--- a/Shelly-CLI/Commands/Standard/AppImageInstallCommand.cs
+++ b/Shelly-CLI/Commands/Standard/AppImageInstallCommand.cs
@@ -37,6 +37,7 @@ public class AppImageInstallCommand : AsyncCommand<AppImageInstallSettings>
             return 1;
         }
 
+        RootElevator.EnsureRootExectuion();
         if (await IsAppImage(settings.PackageLocation))
         {
             return await InstallAppImage(settings);

--- a/Shelly-CLI/Commands/Standard/DowngradePackageCommand.cs
+++ b/Shelly-CLI/Commands/Standard/DowngradePackageCommand.cs
@@ -26,6 +26,7 @@ public class DowngradePackageCommand : Command<DowngradePackageCommandSettings>
             return 1;
         }
 
+        RootElevator.EnsureRootExectuion();
         var package = settings.Packages[0];
         AnsiConsole.MarkupLine($"[yellow]Looking for downgrade options for:[/]: {package}");
 

--- a/Shelly-CLI/Commands/Standard/InstallCommand.cs
+++ b/Shelly-CLI/Commands/Standard/InstallCommand.cs
@@ -22,6 +22,7 @@ public class InstallCommand : Command<InstallPackageSettings>
             AnsiConsole.MarkupLine("[red]Error: No packages specified[/]");
             return 1;
         }
+        RootElevator.EnsureRootExectuion();
 
         var packageList = settings.Packages.ToList();
 

--- a/Shelly-CLI/Commands/Standard/InstallLocalPackageCommand.cs
+++ b/Shelly-CLI/Commands/Standard/InstallLocalPackageCommand.cs
@@ -27,6 +27,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             {
                 AnsiConsole.MarkupLine("[red]Error: No package specified[/]");
             }
+
             return 1;
         }
 
@@ -40,8 +41,11 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             {
                 AnsiConsole.MarkupLine("[red]Error: Specified file does not exist.[/]");
             }
+
             return 1;
         }
+
+        RootElevator.EnsureRootExectuion();
 
         if (await IsArchPackage(settings.PackageLocation))
         {
@@ -49,6 +53,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             {
                 return HandleUiModeInstall(settings);
             }
+
             InitializeAndInstallLocalAlpmPackage(settings);
             return 0;
         }
@@ -147,7 +152,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
         foreach (var binaryName in installedBinaries)
         {
             var iconName = "application-x-executable";
-            
+
             if (packageName.Contains(binaryName, StringComparison.OrdinalIgnoreCase))
             {
                 if (foundIcons.Count > 0)
@@ -282,16 +287,10 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
         try
         {
             // Handle questions
-            manager.Question += (sender, args) =>
-            {
-                QuestionHandler.HandleQuestion(args, true, settings.NoConfirm);
-            };
+            manager.Question += (sender, args) => { QuestionHandler.HandleQuestion(args, true, settings.NoConfirm); };
 
             // Handle progress events
-            manager.Progress += (sender, args) =>
-            {
-                Console.Error.WriteLine($"{args.PackageName}: {args.Percent}%");
-            };
+            manager.Progress += (sender, args) => { Console.Error.WriteLine($"{args.PackageName}: {args.Percent}%"); };
 
             Console.Error.WriteLine("Initializing ALPM...");
             manager.Initialize();

--- a/Shelly-CLI/Commands/Standard/RemoveCommand.cs
+++ b/Shelly-CLI/Commands/Standard/RemoveCommand.cs
@@ -23,7 +23,7 @@ public class RemoveCommand : Command<RemovePackageSettings>
             AnsiConsole.MarkupLine("[red]Error: No packages specified[/]");
             return 1;
         }
-
+        RootElevator.EnsureRootExectuion();
         var packageList = settings.Packages.ToList();
 
         AnsiConsole.MarkupLine($"[yellow]Packages to remove:[/] {string.Join(", ", packageList)}");

--- a/Shelly-CLI/Commands/Standard/SyncCommand.cs
+++ b/Shelly-CLI/Commands/Standard/SyncCommand.cs
@@ -15,6 +15,7 @@ public class SyncCommand : Command<SyncSettings>
             return HandleUiMode(settings);
         }
 
+        RootElevator.EnsureRootExectuion();
         using var manager = new AlpmManager();
         object renderLock = new();
 

--- a/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
@@ -18,6 +18,7 @@ public class UpgradeCommand : Command<UpgradeSettings>
             return HandleUiModeUpgrade(settings);
         }
 
+        RootElevator.EnsureRootExectuion();
         var archNews = new ArchNews();
         archNews.ExecuteAsync(context, new ArchNewsSettings()).GetAwaiter().GetResult();
 

--- a/Shelly-CLI/RootElevator.cs
+++ b/Shelly-CLI/RootElevator.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+
+namespace Shelly_CLI;
+
+public static class RootElevator
+{
+    public static void EnsureRootExectuion()
+    {
+        var user = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
+        if (user.Equals("root", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var args = Environment.GetCommandLineArgs();
+        var exe = Environment.ProcessPath ?? args[0];
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "sudo",
+                ArgumentList = { exe },
+                UseShellExecute = false,
+
+            }
+        };
+        foreach (var arg in args.Skip(1))
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        process.Start();
+        process.WaitForExit();
+        Environment.Exit(process.ExitCode);
+    }
+}


### PR DESCRIPTION
- Introduced `RootElevator.EnsureRootExectuion` method to standardize privilege elevation.
- Integrated privilege checks into keyring, standard, and AUR command implementations.
- Refactored command logic to ensure proper execution under elevated permissions when required.