### PR TITLE
Add upgrade option to package installation workflows

### DIFF
--- a/Shelly-CLI/Commands/Standard/InstallCommand.cs
+++ b/Shelly-CLI/Commands/Standard/InstallCommand.cs
@@ -14,7 +14,7 @@ public class InstallCommand : Command<InstallPackageSettings>
     {
         if (Program.IsUiMode)
         {
-            return HandleUiModeInstall(settings);
+            return HandleUiModeInstall(context,settings);
         }
 
         if (settings.Packages.Length == 0)
@@ -22,6 +22,7 @@ public class InstallCommand : Command<InstallPackageSettings>
             AnsiConsole.MarkupLine("[red]Error: No packages specified[/]");
             return 1;
         }
+
         RootElevator.EnsureRootExectuion();
 
         var packageList = settings.Packages.ToList();
@@ -48,7 +49,12 @@ public class InstallCommand : Command<InstallPackageSettings>
         };
 
         AnsiConsole.MarkupLine("[yellow]Initializing and syncing ALPM...[/]");
-        manager.IntializeWithSync();
+        manager.Initialize(true);
+        if (settings.Upgrade)
+        {
+            AnsiConsole.Markup("[yellow]Running system upgrade[/yellow]");
+            manager.SyncSystemUpdate();
+        }
 
         if (settings.BuildDepsOn)
         {
@@ -129,7 +135,7 @@ public class InstallCommand : Command<InstallPackageSettings>
         return 0;
     }
 
-    private static int HandleUiModeInstall(InstallPackageSettings settings)
+    private static int HandleUiModeInstall(CommandContext context, InstallPackageSettings settings)
     {
         if (settings.Packages.Length == 0)
         {
@@ -137,10 +143,20 @@ public class InstallCommand : Command<InstallPackageSettings>
             return 1;
         }
 
+        if (settings.Upgrade)
+        {
+            var command = new UpgradeCommand();
+            command.Execute(context, new UpgradeSettings()
+            {
+                JsonOutput = true,
+            });
+        }
+
         var manager = new AlpmManager();
         manager.Question += (sender, args) => { QuestionHandler.HandleQuestion(args, true, settings.NoConfirm); };
         Console.Error.WriteLine("Initializing and syncing ALPM...");
-        manager.IntializeWithSync();
+        manager.Initialize(true);
+
         if (settings.BuildDepsOn)
         {
             if (settings.Packages.Length > 1)

--- a/Shelly-CLI/Commands/Standard/InstallPackageSettings.cs
+++ b/Shelly-CLI/Commands/Standard/InstallPackageSettings.cs
@@ -16,4 +16,8 @@ public class InstallPackageSettings : PackageSettings
     [CommandOption("-d | --no-deps")]
     [Description("Install package without checking/installing dependencies")]
     public bool NoDeps { get; set; }
+
+    [CommandOption("-u | --upgrade")]
+    [Description("Triggers full system upgrade with install")]
+    public bool Upgrade { get; set; }
 }

--- a/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
@@ -218,7 +218,7 @@ public class UpgradeCommand : Command<UpgradeSettings>
         return 0;
     }
 
-    private string CalculateDownside(SizeDisplay size, long downloadSize)
+    private static string CalculateDownside(SizeDisplay size, long downloadSize)
     {
         return size switch
         {

--- a/Shelly.Gtk/Services/IPrivilegedOperationService.cs
+++ b/Shelly.Gtk/Services/IPrivilegedOperationService.cs
@@ -9,7 +9,7 @@ public interface IPrivilegedOperationService
 {
     Task<OperationResult> SyncDatabasesAsync();
     Task<List<AlpmPackageDto>> SearchPackagesAsync(string query);
-    Task<OperationResult> InstallPackagesAsync(IEnumerable<string> packages);
+    Task<OperationResult> InstallPackagesAsync(IEnumerable<string> packages, bool upgrade = false);
     Task<OperationResult> InstallLocalPackageAsync(string filePath);
     Task<OperationResult> InstallAppImageAsync(string filePath);
     Task<OperationResult> RemovePackagesAsync(IEnumerable<string> packages, bool isCascade, bool isCleanup);

--- a/Shelly.Gtk/Services/PrivilegedOperationService.cs
+++ b/Shelly.Gtk/Services/PrivilegedOperationService.cs
@@ -121,9 +121,13 @@ public class PrivilegedOperationService : IPrivilegedOperationService
         }
     }
 
-    public async Task<OperationResult> InstallPackagesAsync(IEnumerable<string> packages)
+    public async Task<OperationResult> InstallPackagesAsync(IEnumerable<string> packages, bool upgrade = false)
     {
         var packageArgs = string.Join(" ", packages);
+        if (upgrade)
+        {
+            packageArgs += " -u";
+        }
         return await ExecutePrivilegedWithNoConfirmCheck("Install packages", "install", packageArgs);
     }
 

--- a/Shelly.Gtk/UiFiles/Package/PackageWindow.ui
+++ b/Shelly.Gtk/UiFiles/Package/PackageWindow.ui
@@ -79,15 +79,15 @@
               </object>
             </child>
             <child>
-              <object class="GtkSearchEntry" id="search_entry">
-                <property name="placeholder-text">Search packages...</property>
-                <property name="width-request">200</property>
+              <object class="GtkCheckButton" id="upgrade_check">
+                <property name="label">Perform Upgrade</property>
+                <property name="tooltip-text">Perform a full system upgrade with install (-u)</property>
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="sync_button">
-                <property name="icon-name">view-refresh-symbolic</property>
-                <property name="tooltip-text">Sync</property>
+              <object class="GtkSearchEntry" id="search_entry">
+                <property name="placeholder-text">Search packages...</property>
+                <property name="width-request">200</property>
               </object>
             </child>
           </object>

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -54,6 +54,7 @@ public class PackageInstall(
     private ColumnViewColumn _versionColumn = null!;
     private ColumnViewColumn _repositoryColumn = null!;
     private DropDown _groupDropDown = null!;
+    private CheckButton _upgradeCheck = null!;
 
     private Revealer _detailRevealer = null!;
     private Box _detailBox = null!;
@@ -82,6 +83,7 @@ public class PackageInstall(
         _detailRevealer = (Revealer)_builder.GetObject("detail_revealer")!;
         _detailBox = (Box)_builder.GetObject("detail_box")!;
         _groupDropDown = (DropDown)_builder.GetObject("grouping_selection")!;
+        _upgradeCheck = (CheckButton)_builder.GetObject("upgrade_check")!;
 
         _listStore = Gio.ListStore.New(AlpmPackageGObject.GetGType());
         _filter = CustomFilter.New(FilterPackage);
@@ -554,7 +556,8 @@ public class PackageInstall(
                 }
 
                 lockoutService.Show($"Installing...");
-                await privilegedOperationService.InstallPackagesAsync(selectedPackages);
+                var performUpgrade = _upgradeCheck.GetActive();
+                await privilegedOperationService.InstallPackagesAsync(selectedPackages, performUpgrade);
                 await LoadDataAsync();
             }
             catch (Exception e)


### PR DESCRIPTION
- Introduced "Perform Upgrade" checkbox to `PackageWindow` for triggering full system upgrades.
- Extended `InstallPackagesAsync` to support an optional `upgrade` flag.
- Updated CLI install command to include `--upgrade` option for system upgrades.
- Adjusted UI and backend logic to handle upgrade scenarios seamlessly.