### PR TITLE
Fixing #249 by making the ListBoxRow non Activatable

### DIFF
--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -494,6 +494,7 @@ public class HomeWindow(
             vbox.Append(date);
             vbox.Append(desc);
 
+            row.SetActivatable(false);
             row.SetChild(vbox);
             listBox.Append(row);
         }


### PR DESCRIPTION
While I was not able to test it with the Edna theme since Shelly only follows the GTK theme for me. I am confident that it should do the trick since it removes the Highlight altogether as requested in the #249 issue.