### PR TITLE
Add support for package search and selection in `DefaultCommand` usin…

### DIFF
--- a/Shelly-CLI/Commands/DefaultCommand.cs
+++ b/Shelly-CLI/Commands/DefaultCommand.cs
@@ -1,17 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using PackageManager.Alpm;
+using PackageManager.Aur;
+using PackageManager.Aur.Models;
 using Shelly_CLI.Commands.Aur;
 using Shelly_CLI.Commands.Flatpak;
 using Shelly_CLI.Commands.Standard;
 using Shelly_CLI.Configuration;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Shelly_CLI.Commands;
 
-public class DefaultCommand : AsyncCommand
+public class DefaultCommand : AsyncCommand<DefaultCommandSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context)
+    public override async Task<int> ExecuteAsync(CommandContext context, [NotNull] DefaultCommandSettings settings)
     {
-        var username = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;;
+        var username = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
+        ;
         var configPath = Path.Combine("/home", username, ".config", "shelly", "config.json");
         Console.WriteLine(configPath);
         if (!File.Exists(configPath))
@@ -25,6 +31,38 @@ public class DefaultCommand : AsyncCommand
         if (config == null)
         {
             return 1;
+        }
+
+        if (!string.IsNullOrEmpty(settings.SearchString))
+        {
+            RootElevator.EnsureRootExectuion();
+            var standard = SearchStandard(settings.SearchString);
+            var aur = SearchAur(settings.SearchString);
+            var selection = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title($"[yellow]Found {standard.Count + aur.Count} packages please select one to install[/]")
+                    .AddChoices(standard.Select(x => $"{x.Name} : {x.Version} : Standard"))
+                    .AddChoices(aur.Select(x => $"{x.Name} : {x.Version} : AUR")));
+            var selectionArray = selection.Split(":");
+            var name = selectionArray[0].Trim();
+            Console.WriteLine(name);
+            var repo = selectionArray[2].Trim();
+            if (repo == "AUR")
+            {
+                new Aur.AurInstallCommand().ExecuteAsync(context, new AurInstallSettings()
+                {
+                    Packages = [name]
+                }).Wait();
+            }
+            else
+            {
+                new InstallCommand().Execute(context, new InstallPackageSettings()
+                {
+                    Packages = [name]
+                });
+            }
+
+            return 0;
         }
 
         var parsed =
@@ -46,5 +84,35 @@ public class DefaultCommand : AsyncCommand
                 new ListSettings()),
             _ => 1
         };
+    }
+
+    private List<AlpmPackageDto> SearchStandard(string filter)
+    {
+        var manager = new AlpmManager();
+        manager.Initialize();
+        var packages = manager.GetAvailablePackages();
+        packages = packages.Select(x => new { Package = x, Score = StringMatching.PartialRatio(filter, x.Name) })
+            .Where(x => x.Score >= 75)
+            .OrderByDescending(x => x.Score)
+            .Select(x => x.Package)
+            .Take(5) //Add configuration here to control amount visible.
+            .ToList();
+        manager.Dispose();
+        return packages;
+    }
+
+    private List<AurPackageDto> SearchAur(string filter)
+    {
+        var manager = new AurPackageManager();
+        manager.Initialize().Wait();
+        var packages = manager.SearchPackages(filter).Result;
+        packages = packages.Select(x => new { Package = x, Score = StringMatching.PartialRatio(filter, x.Name) })
+            .Where(x => x.Score >= 75)
+            .OrderByDescending(x => x.Score)
+            .Select(x => x.Package)
+            .Take(5) //Add configuration here to control amount visible.
+            .ToList();
+        manager.Dispose();
+        return packages;
     }
 }

--- a/Shelly-CLI/Commands/DefaultCommandSettings.cs
+++ b/Shelly-CLI/Commands/DefaultCommandSettings.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Shelly_CLI.Commands;
+
+public class DefaultCommandSettings : CommandSettings
+{
+    [CommandArgument(0, "[SearchString]")]
+    [Description("Search")]
+    public string SearchString { get; set; } = string.Empty;
+}

--- a/Shelly-CLI/Program.cs
+++ b/Shelly-CLI/Program.cs
@@ -77,8 +77,7 @@ public class Program
             });
         }
 
-        var app = new CommandApp();
-        app.SetDefaultCommand<Commands.DefaultCommand>();
+        var app = new CommandApp<Commands.DefaultCommand>();
         app.Configure(config =>
         {
             config.SetApplicationName("shelly");

--- a/Shelly-CLI/StringMatching.cs
+++ b/Shelly-CLI/StringMatching.cs
@@ -1,0 +1,37 @@
+namespace Shelly_CLI;
+
+public static class StringMatching
+{
+    public static int CalculateLevenshteinDistance(string s, string t)
+    {
+        var d = new int[s.Length + 1, t.Length + 1];
+        for (var i = 0; i <= s.Length; i++) d[i, 0] = i;
+        for (var j = 0; j <= t.Length; j++) d[0, j] = j;
+        for (var i = 1; i <= s.Length; i++)
+        for (var j = 1; j <= t.Length; j++)
+            d[i, j] = Math.Min(
+                Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                d[i - 1, j - 1] + (s[i - 1] == t[j - 1] ? 0 : 1));
+        return d[s.Length, t.Length];
+    }
+
+    public static int PartialRatio(string s, string t)
+    {
+        if (s.Length > t.Length)
+            (s, t) = (t, s);
+
+        var bestScore = 0;
+        for (var i = 0; i <= t.Length - s.Length; i++)
+        {
+            var substring = t.Substring(i, s.Length);
+            var dist = CalculateLevenshteinDistance(s.ToLower(), substring.ToLower());
+            var score = (int)((1.0 - (double)dist / s.Length) * 100);
+            if (score > bestScore)
+            {
+                bestScore = score;
+            }
+        }
+
+        return bestScore;
+    }
+}

--- a/Shelly-CLI/rd.xml
+++ b/Shelly-CLI/rd.xml
@@ -9,6 +9,7 @@
             <Type Name="Shelly_CLI.SortDirection" Dynamic="Required All"/>
             <!-- Standard commands -->
             <Type Name="Shelly_CLI.Commands.DefaultCommand" Dynamic="Required All"/>
+            <Type Name="Shelly_CLI.Commands.DefaultCommandSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.VersionCommand" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.SyncSettings" Dynamic="Required All"/>
             <Type Name="Shelly_CLI.Commands.Standard.SyncCommand" Dynamic="Required All"/>


### PR DESCRIPTION
…g `DefaultCommandSettings`

- Introduced `DefaultCommandSettings` for handling search string arguments.
- Implemented package search logic for Standard and AUR repositories with fuzzy matching.
- Added a selection prompt for package installation during searches.
- Refactored program entry to use `CommandApp<T>` with `DefaultCommand`.