### PR TITLE
Bump version to 2.0.6 and update project, package metadata, and CLI e…

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Zoey Bauer <zoey.erin.bauer@gmail.com>
 # Maintainer: Caroline Snyder <hirpeng@gmail.com>
 pkgname=shelly
-pkgver=2.0.5
+pkgver=2.0.6
 pkgrel=1
 pkgdesc="Shelly: A Modern Arch Package Manager"
 arch=('x86_64')

--- a/PKGBUILD-bin
+++ b/PKGBUILD-bin
@@ -1,7 +1,7 @@
 # Maintainer: Zoey Bauer <zoey.erin.bauer@gmail.com>
 # Maintainer: Caroline Snyder <hirpeng@gmail.com>
 pkgname=shelly-bin
-pkgver=2.0.5
+pkgver=2.0.6
 pkgrel=1
 pkgdesc="Shelly: A Modern Arch Package Manager (prebuilt binary)"
 arch=('x86_64')

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -1,7 +1,7 @@
 # Maintainer: Zoey Bauer <zoey.erin.bauer@gmail.com>
 # Maintainer: Caroline Snyder <hirpeng@gmail.com>
 pkgname=shelly-git
-pkgver=2.0.5
+pkgver=2.0.6
 pkgrel=1
 pkgdesc="Shelly: A Modern Arch Package Manager (git version)"
 arch=('x86_64')

--- a/Shelly-CLI/Program.cs
+++ b/Shelly-CLI/Program.cs
@@ -99,6 +99,7 @@ public class Program
                 .WithExample("sync");
 
             config.AddCommand<ListInstalledCommand>("list-installed")
+                .WithAlias("li")
                 .WithDescription("List all installed packages")
                 .WithExample("list-installed")
                 .WithExample("list-installed", "--sort", "name")

--- a/Shelly-CLI/Shelly-CLI.csproj
+++ b/Shelly-CLI/Shelly-CLI.csproj
@@ -12,9 +12,9 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>2.0.5</Version>
+        <Version>2.0.6</Version>
         <AssemblyName>shelly</AssemblyName>
-        <AssemblyVersion>2.0.5</AssemblyVersion>
+        <AssemblyVersion>2.0.6</AssemblyVersion>
         <AssemblyTitle>Shelly CLI</AssemblyTitle>
         <Description>Shelly CLI is a arch linux package manager</Description>
         <Company>Seafoam Labs</Company>

--- a/Shelly-Notifications/Shelly-Notifications.csproj
+++ b/Shelly-Notifications/Shelly-Notifications.csproj
@@ -18,8 +18,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>2.0.5</Version>
-        <AssemblyVersion>2.0.5</AssemblyVersion>
+        <Version>2.0.6</Version>
+        <AssemblyVersion>2.0.6</AssemblyVersion>
         <AssemblyTitle>Shelly VALPM</AssemblyTitle>
         <Description>Shelly is a visual arch linux package manager</Description>
         <Company>Seafoam Labs</Company>

--- a/Shelly.Gtk/Shelly.Gtk.csproj
+++ b/Shelly.Gtk/Shelly.Gtk.csproj
@@ -17,9 +17,9 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>2.0.5</Version>
+        <Version>2.0.6</Version>
         <AssemblyName>shelly-ui</AssemblyName>
-        <AssemblyVersion>2.0.5</AssemblyVersion>
+        <AssemblyVersion>2.0.6</AssemblyVersion>
         <AssemblyTitle>Shelly GTK UI</AssemblyTitle>
         <Description>Shelly GTK is a arch linux package manager</Description>
         <Company>Seafoam Labs</Company>

--- a/Shelly.Gtk/UiFiles/MainWindow.ui
+++ b/Shelly.Gtk/UiFiles/MainWindow.ui
@@ -52,7 +52,7 @@
   <object class="GtkApplicationWindow" id="MainWindow">
     <property name="default-height">600</property>
     <property name="default-width">800</property>
-    <property name="title">Shelly GTK</property>
+    <property name="title">Shelly</property>
     <child>
       <object class="GtkOverlay" id="MainOverlay">
         <property name="child">


### PR DESCRIPTION
…nhancements

- Updated version in all project files, PKGBUILDs, and assembly properties to 2.0.6.
- Changed GTK window title from "Shelly GTK" to "Shelly".
- Added `list-installed` alias (`li`) in CLI commands for easier usage.