### PR TITLE
Fix app ID + .desktop name mismatch issue

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -53,7 +53,7 @@ package() {
   install -Dm755 out-cli/shelly "$pkgdir/usr/bin/shelly"
 
   # Install desktop entry
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/shelly.desktop"
+  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
 [Desktop Entry]
 Name=Shelly
 Comment=A Modern Arch Package Manager

--- a/PKGBUILD-bin
+++ b/PKGBUILD-bin
@@ -43,7 +43,7 @@ package() {
   install -Dm755 "$srcdir/shelly" "$pkgdir/usr/bin/shelly"
 
   # Install desktop entry
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/shelly.desktop"
+  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
 [Desktop Entry]
 Name=Shelly
 Comment=A Modern Arch Package Manager

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -58,7 +58,7 @@ package() {
   install -Dm755 out-cli/shelly "$pkgdir/usr/bin/shelly"
 
   # Install desktop entry
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/shelly.desktop"
+  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
 [Desktop Entry]
 Name=Shelly
 Comment=A Modern Arch Package Manager

--- a/local-install.sh
+++ b/local-install.sh
@@ -85,7 +85,7 @@ cp "$INSTALL_DIR/shellylogo.png" /usr/share/icons/hicolor/256x256/apps/shelly.pn
 
 # Create desktop entry
 echo "Creating desktop entry"
-cat <<EOF > /usr/share/applications/shelly.desktop
+cat <<EOF > /usr/share/applications/com.shellyorg.shelly.desktop
 [Desktop Entry]
 Name=Shelly
 Comment=A Modern Arch Package Manager

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -53,8 +53,13 @@ if [ -f /usr/lib/libHarfBuzzSharp.so ]; then
 fi
 
 # Remove desktop entry
-if [ -f /usr/share/applications/shelly.desktop ]; then
+if [ -f /usr/share/applications/com.shellyorg.shelly.desktop ]; then
     echo "Removing desktop entry"
+    rm -f /usr/share/applications/com.shellyorg.shelly.desktop
+fi
+# Remove old desktop entry
+if [ -f /usr/share/applications/shelly.desktop ]; then
+    echo "Removing broken pre-GTK desktop entry"
     rm -f /usr/share/applications/shelly.desktop
 fi
 


### PR DESCRIPTION
Since going GTK, the GTK-enforced app ID is mismatched with the `shelly.desktop` filename. This causes an issue on GNOME in particular (see attached) where it is unable to use the .desktop information on launch, assigning a generic app ID name and icon. I am unsure specifically *why* this would only occur on GNOME - perhaps KDE decided to trim the `com.shellyorg.` in its search?

I have tried to as comprehensively as possible fix all definitions across the board, including install/uninstall scripts. If there is a better solution, or I've missed anything, please let me know. Thank you.

<img width="252" height="107" alt="image" src="https://github.com/user-attachments/assets/9cdcd519-0e3e-40d8-86f4-12a1d88a5ba9" />
