### PR TITLE
Add Flatpak integration for desktop actions and right-click menu

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,6 +8,7 @@ arch=('x86_64')
 url="https://github.com/ZoeyErinBauer/Shelly-ALPM"
 license=('GPL-3.0-only')
 provides=('shelly')
+conflicts=('shelly-git' 'shelly-bin')
 depends=(
     'pacman'
     'gtk4'
@@ -19,10 +20,9 @@ depends=(
     'hicolor-icon-theme'
     'dbus'
     'glibc'
-    'glib2'
 )
 optdepends=(
-    'flatpak:  For supporting flatpak implementation.'
+    'flatpak: For supporting flatpak implementation.'
     'archlinux-appstream-data: package icons and metadata'
     'fish: Fish shell completions'
 )
@@ -63,6 +63,22 @@ Icon=shelly
 Type=Application
 Categories=System;Utility;
 Terminal=false
+Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
+
+[Desktop Action FlatpakInstall]
+Name=Flatpak Install
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-install
+
+[Desktop Action FlatpakUpdate]
+Name=Flatpak Update
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-update
+
+[Desktop Action FlatpakRemove]
+Name=Flatpak Remove
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-remove
 EOF
 
   # Install desktop entry for notification service
@@ -85,4 +101,50 @@ EOF
 
   # Install fish shell completions
   install -Dm644 shelly.fish "$pkgdir/usr/share/fish/vendor_completions.d/shelly.fish"
+
+  # Install Flatpak integration script
+  cat <<'SCRIPT' | install -Dm755 /dev/stdin "$pkgdir/usr/bin/shelly-flatpak-integrate"
+#!/bin/bash
+# Adds "Manage in Shelly" right-click action to all Flatpak .desktop files
+FLATPAK_DIRS=(
+    "/var/lib/flatpak/exports/share/applications"
+    "$HOME/.local/share/flatpak/exports/share/applications"
+)
+LOCAL_APPS_DIR="$HOME/.local/share/applications"
+mkdir -p "$LOCAL_APPS_DIR"
+
+for dir in "${FLATPAK_DIRS[@]}"; do
+    [ -d "$dir" ] || continue
+    for desktop_file in "$dir"/*.desktop; do
+        [ -f "$desktop_file" ] || continue
+        filename=$(basename "$desktop_file")
+        app_id="${filename%.desktop}"
+        dest="$LOCAL_APPS_DIR/$filename"
+
+        # Copy if override doesn't exist yet
+        [ -f "$dest" ] || cp "$desktop_file" "$dest"
+
+        # Skip if already patched
+        grep -q "ShellyManage" "$dest" && continue
+
+        # Add action to existing Actions= line or insert one
+        if grep -q "^Actions=" "$dest"; then
+            sed -i 's/^Actions=\(.*\)/Actions=\1ShellyManage;/' "$dest"
+        else
+            sed -i '/^\[Desktop Entry\]/a Actions=ShellyManage;' "$dest"
+        fi
+
+        cat >> "$dest" << EOF
+
+[Desktop Action ShellyManage]
+Name=Manage in Shelly
+Icon=shelly
+Exec=/usr/bin/shelly-ui --page flatpak-install
+EOF
+    done
+done
+
+update-desktop-database "$LOCAL_APPS_DIR" 2>/dev/null || true
+echo "Flatpak desktop entries patched with Shelly integration."
+SCRIPT
 }

--- a/PKGBUILD-bin
+++ b/PKGBUILD-bin
@@ -53,6 +53,22 @@ Icon=shelly
 Type=Application
 Categories=System;Utility;
 Terminal=false
+Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
+
+[Desktop Action FlatpakInstall]
+Name=Flatpak Install
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-install
+
+[Desktop Action FlatpakUpdate]
+Name=Flatpak Update
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-update
+
+[Desktop Action FlatpakRemove]
+Name=Flatpak Remove
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-remove
 EOF
 
   # Install desktop entry for notification service
@@ -75,4 +91,50 @@ EOF
 
   # Install fish shell completions
   install -Dm644 "$srcdir/shelly.fish" "$pkgdir/usr/share/fish/vendor_completions.d/shelly.fish"
+
+  # Install Flatpak integration script
+  cat <<'SCRIPT' | install -Dm755 /dev/stdin "$pkgdir/usr/bin/shelly-flatpak-integrate"
+#!/bin/bash
+# Adds "Manage in Shelly" right-click action to all Flatpak .desktop files
+FLATPAK_DIRS=(
+    "/var/lib/flatpak/exports/share/applications"
+    "$HOME/.local/share/flatpak/exports/share/applications"
+)
+LOCAL_APPS_DIR="$HOME/.local/share/applications"
+mkdir -p "$LOCAL_APPS_DIR"
+
+for dir in "${FLATPAK_DIRS[@]}"; do
+    [ -d "$dir" ] || continue
+    for desktop_file in "$dir"/*.desktop; do
+        [ -f "$desktop_file" ] || continue
+        filename=$(basename "$desktop_file")
+        app_id="${filename%.desktop}"
+        dest="$LOCAL_APPS_DIR/$filename"
+
+        # Copy if override doesn't exist yet
+        [ -f "$dest" ] || cp "$desktop_file" "$dest"
+
+        # Skip if already patched
+        grep -q "ShellyManage" "$dest" && continue
+
+        # Add action to existing Actions= line or insert one
+        if grep -q "^Actions=" "$dest"; then
+            sed -i 's/^Actions=\(.*\)/Actions=\1ShellyManage;/' "$dest"
+        else
+            sed -i '/^\[Desktop Entry\]/a Actions=ShellyManage;' "$dest"
+        fi
+
+        cat >> "$dest" << EOF
+
+[Desktop Action ShellyManage]
+Name=Manage in Shelly
+Icon=shelly
+Exec=/usr/bin/shelly-ui --page flatpak-install
+EOF
+    done
+done
+
+update-desktop-database "$LOCAL_APPS_DIR" 2>/dev/null || true
+echo "Flatpak desktop entries patched with Shelly integration."
+SCRIPT
 }

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -68,6 +68,22 @@ Icon=shelly
 Type=Application
 Categories=System;Utility;
 Terminal=false
+Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
+
+[Desktop Action FlatpakInstall]
+Name=Flatpak Install
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-install
+
+[Desktop Action FlatpakUpdate]
+Name=Flatpak Update
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-update
+
+[Desktop Action FlatpakRemove]
+Name=Flatpak Remove
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-remove
 EOF
 
   # Install desktop entry for notification service
@@ -90,4 +106,50 @@ EOF
 
   # Install fish shell completions
   install -Dm644 shelly.fish "$pkgdir/usr/share/fish/vendor_completions.d/shelly.fish"
+
+  # Install Flatpak integration script
+  cat <<'SCRIPT' | install -Dm755 /dev/stdin "$pkgdir/usr/bin/shelly-flatpak-integrate"
+#!/bin/bash
+# Adds "Manage in Shelly" right-click action to all Flatpak .desktop files
+FLATPAK_DIRS=(
+    "/var/lib/flatpak/exports/share/applications"
+    "$HOME/.local/share/flatpak/exports/share/applications"
+)
+LOCAL_APPS_DIR="$HOME/.local/share/applications"
+mkdir -p "$LOCAL_APPS_DIR"
+
+for dir in "${FLATPAK_DIRS[@]}"; do
+    [ -d "$dir" ] || continue
+    for desktop_file in "$dir"/*.desktop; do
+        [ -f "$desktop_file" ] || continue
+        filename=$(basename "$desktop_file")
+        app_id="${filename%.desktop}"
+        dest="$LOCAL_APPS_DIR/$filename"
+
+        # Copy if override doesn't exist yet
+        [ -f "$dest" ] || cp "$desktop_file" "$dest"
+
+        # Skip if already patched
+        grep -q "ShellyManage" "$dest" && continue
+
+        # Add action to existing Actions= line or insert one
+        if grep -q "^Actions=" "$dest"; then
+            sed -i 's/^Actions=\(.*\)/Actions=\1ShellyManage;/' "$dest"
+        else
+            sed -i '/^\[Desktop Entry\]/a Actions=ShellyManage;' "$dest"
+        fi
+
+        cat >> "$dest" << EOF
+
+[Desktop Action ShellyManage]
+Name=Manage in Shelly
+Icon=shelly
+Exec=/usr/bin/shelly-ui --page flatpak-install
+EOF
+    done
+done
+
+update-desktop-database "$LOCAL_APPS_DIR" 2>/dev/null || true
+echo "Flatpak desktop entries patched with Shelly integration."
+SCRIPT
 }

--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -17,13 +17,33 @@ namespace Shelly.Gtk;
 
 sealed class Program
 {
+    private static string? _requestedPage;
+
     public static int Main(string[] args)
     {
         //GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency;
+
+        // Parse --page argument
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--page" && i + 1 < args.Length)
+            {
+                _requestedPage = args[i + 1];
+                break;
+            }
+        }
+
         ServiceCollection serviceCollection = new();
         var serviceProvider = ServiceBuilder.CreateDependencyInjection(serviceCollection);
 
-        var application = Application.New(ShellyConstants.Service, Gio.ApplicationFlags.DefaultFlags);
+        var application = Application.New(ShellyConstants.Service,
+            Gio.ApplicationFlags.DefaultFlags | Gio.ApplicationFlags.HandlesCommandLine);
+
+        application.OnCommandLine += (sender, e) =>
+        {
+            application.Activate();
+            return 0;
+        };
 
 
         application.OnActivate += (sender, _) =>
@@ -150,6 +170,41 @@ sealed class Program
             var initialHomeWindow = serviceProvider.GetRequiredService<HomeWindow>();
             contentArea.Append(initialHomeWindow.CreateWindow());
             currentPage = initialHomeWindow;
+
+            // Navigate to requested page from CLI args
+            if (_requestedPage != null)
+            {
+                switch (_requestedPage)
+                {
+                    case "flatpak-install":
+                        NavigateTo<FlatpakInstall>();
+                        break;
+                    case "flatpak-update":
+                        NavigateTo<FlatpakUpdate>();
+                        break;
+                    case "flatpak-remove":
+                        NavigateTo<FlatpakRemove>();
+                        break;
+                    case "aur-install":
+                        NavigateTo<AurInstall>();
+                        break;
+                    case "aur-update":
+                        NavigateTo<AurUpdate>();
+                        break;
+                    case "aur-remove":
+                        NavigateTo<AurRemove>();
+                        break;
+                    case "install-packages":
+                        NavigateTo<PackageInstall>();
+                        break;
+                    case "update-packages":
+                        NavigateTo<PackageUpdate>();
+                        break;
+                    case "manage-packages":
+                        NavigateTo<PackageManagement>();
+                        break;
+                }
+            }
 
             var mainOverlay = (Overlay)mainBuilder.GetObject("MainOverlay")!;
             var lockoutDialog = serviceProvider.GetRequiredService<LockoutDialog>();


### PR DESCRIPTION
- Introduced `FlatpakInstall`, `FlatpakUpdate`, and `FlatpakRemove` desktop actions in PKGBUILD files.
- Added a script to integrate Shelly actions into Flatpak application `.desktop` files.
- Updated application to support navigation to specific Flatpak-related pages via CLI.