### PR TITLE
Escape markup in all CLI output strings for safer rendering with `Ans…

### DIFF
--- a/Shelly-CLI/Commands/Aur/AurInstallCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurInstallCommand.cs
@@ -29,7 +29,7 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
 
         var packageList = settings.Packages.ToList();
 
-        AnsiConsole.MarkupLine($"[yellow]AUR packages to install:[/] {string.Join(", ", packageList)}");
+        AnsiConsole.MarkupLine($"[yellow]AUR packages to install:[/] {string.Join(", ", packageList.Select(p => p.EscapeMarkup()))}");
 
         if (!Program.IsUiMode)
         {
@@ -62,7 +62,7 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
                     };
 
                     AnsiConsole.MarkupLine(
-                        $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName}: {args.Status}[/]" +
+                        $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName.EscapeMarkup()}: {args.Status}[/]" +
                         (args.Message != null ? $" - {args.Message.EscapeMarkup()}" : ""));
                 }
             };
@@ -100,7 +100,7 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
                 return 0;
             }
 
-            AnsiConsole.MarkupLine($"[yellow]Installing AUR packages: {string.Join(", ", settings.Packages)}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Installing AUR packages: {string.Join(", ", settings.Packages.Select(p => p.EscapeMarkup()))}[/]");
             var progressTable = new Table().AddColumns("Package", "Progress", "Status", "Stage");
             await AnsiConsole.Live(progressTable).AutoClear(false)
                 .StartAsync(async ctx =>
@@ -145,7 +145,7 @@ public class AurInstallCommand : AsyncCommand<AurInstallSettings>
             if (missingPackages.Count > 0)
             {
                 AnsiConsole.MarkupLine(
-                    $"[red]Installation failed:[/] {string.Join(", ", missingPackages)}");
+                    $"[red]Installation failed:[/] {string.Join(", ", missingPackages.Select(p => p.EscapeMarkup()))}");
                 return 1;
             }
 

--- a/Shelly-CLI/Commands/Aur/AurInstallVersionCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurInstallVersionCommand.cs
@@ -47,12 +47,12 @@ public class AurInstallVersionCommand : AsyncCommand<AurInstallVersionSettings>
                 };
 
                 AnsiConsole.MarkupLine(
-                    $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName}: {args.Status}[/]" +
+                    $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName.EscapeMarkup()}: {args.Status}[/]" +
                     (args.Message != null ? $" - {args.Message.EscapeMarkup()}" : ""));
             };
 
             AnsiConsole.MarkupLine(
-                $"[yellow]Installing AUR package {settings.Package} at commit {settings.Commit}[/]");
+                $"[yellow]Installing AUR package {settings.Package.EscapeMarkup()} at commit {settings.Commit.EscapeMarkup()}[/]");
             await manager.InstallPackageVersion(settings.Package, settings.Commit);
             AnsiConsole.MarkupLine("[green]Installation complete.[/]");
 

--- a/Shelly-CLI/Commands/Aur/AurRemoveCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurRemoveCommand.cs
@@ -49,7 +49,7 @@ public class AurRemoveCommand : AsyncCommand<AurRemovePackageSettings>
                     };
 
                     AnsiConsole.MarkupLine(
-                        $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName}: {args.Status}[/]" +
+                        $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName.EscapeMarkup()}: {args.Status}[/]" +
                         (args.Message != null ? $" - {args.Message.EscapeMarkup()}" : ""));
                 }
             };
@@ -74,7 +74,7 @@ public class AurRemoveCommand : AsyncCommand<AurRemovePackageSettings>
                 flags |= AlpmTransFlag.Cascade;
             }
 
-            AnsiConsole.MarkupLine($"[yellow]Removing AUR packages: {string.Join(", ", settings.Packages)}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Removing AUR packages: {string.Join(", ", settings.Packages.Select(p => p.EscapeMarkup()))}[/]");
             var progressTable = new Table().AddColumns("Package", "Progress", "Status", "Stage");
             await AnsiConsole.Live(progressTable).AutoClear(false)
                 .StartAsync(async ctx =>

--- a/Shelly-CLI/Commands/Aur/AurSearchPackageBuild.cs
+++ b/Shelly-CLI/Commands/Aur/AurSearchPackageBuild.cs
@@ -28,11 +28,11 @@ public class AurSearchPackageBuild : AsyncCommand<AurPackageSettings>
 
                 if (pkgbuild == null)
                 {
-                    AnsiConsole.MarkupLine($"[red]Failed to get pkgbuild for: {package}[/]");
+                    AnsiConsole.MarkupLine($"[red]Failed to get pkgbuild for: {package.EscapeMarkup()}[/]");
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine($"[yellow]Package build for: {package}[/]");
+                    AnsiConsole.MarkupLine($"[yellow]Package build for: {package.EscapeMarkup()}[/]");
                     AnsiConsole.MarkupLine($"{pkgbuild.EscapeMarkup()}");
                 }
             }

--- a/Shelly-CLI/Commands/Aur/AurUpdateCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurUpdateCommand.cs
@@ -44,13 +44,13 @@ public class AurUpdateCommand : AsyncCommand<AurPackageSettings>
                 };
 
                 AnsiConsole.MarkupLine(
-                    $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName}: {args.Status}[/]" +
+                    $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName.EscapeMarkup()}: {args.Status}[/]" +
                     (args.Message != null ? $" - {args.Message.EscapeMarkup()}" : ""));
             };
 
             manager.Progress += (sender, args) =>
             {
-                AnsiConsole.MarkupLine($"[blue]{args.PackageName}[/]: {args.Percent}%");
+                AnsiConsole.MarkupLine($"[blue]{args.PackageName.EscapeMarkup()}[/]: {args.Percent}%");
             };
 
             manager.Question += (sender, args) =>
@@ -71,7 +71,7 @@ public class AurUpdateCommand : AsyncCommand<AurPackageSettings>
                 }
 
                 var showDiff = AnsiConsole.Confirm(
-                    $"[yellow]PKGBUILD changed for {args.PackageName}. View diff?[/]", defaultValue: false);
+                    $"[yellow]PKGBUILD changed for {args.PackageName.EscapeMarkup()}. View diff?[/]", defaultValue: false);
 
                 if (showDiff)
                 {
@@ -82,10 +82,10 @@ public class AurUpdateCommand : AsyncCommand<AurPackageSettings>
                 }
 
                 args.ProceedWithUpdate = AnsiConsole.Confirm(
-                    $"[yellow]Proceed with update for {args.PackageName}?[/]", defaultValue: true);
+                    $"[yellow]Proceed with update for {args.PackageName.EscapeMarkup()}?[/]", defaultValue: true);
             };
 
-            AnsiConsole.MarkupLine($"[yellow]Updating AUR packages: {string.Join(", ", settings.Packages)}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Updating AUR packages: {string.Join(", ", settings.Packages.Select(p => p.EscapeMarkup()))}[/]");
             await manager.UpdatePackages(settings.Packages.ToList());
             AnsiConsole.MarkupLine("[green]Update complete.[/]");
 

--- a/Shelly-CLI/Commands/Aur/AurUpgradeCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurUpgradeCommand.cs
@@ -33,7 +33,7 @@ public class AurUpgradeCommand : AsyncCommand<AurUpgradeSettings>
             AnsiConsole.MarkupLine($"[yellow]{updates.Count} AUR packages need updates:[/]");
             foreach (var pkg in updates)
             {
-                AnsiConsole.MarkupLine($"  {pkg.Name}: {pkg.Version} -> {pkg.NewVersion}");
+                AnsiConsole.MarkupLine($"  {pkg.Name.EscapeMarkup()}: {pkg.Version.EscapeMarkup()} -> {pkg.NewVersion.EscapeMarkup()}");
             }
 
             if (!settings.NoConfirm)
@@ -58,7 +58,7 @@ public class AurUpgradeCommand : AsyncCommand<AurUpgradeSettings>
                 };
 
                 AnsiConsole.MarkupLine(
-                    $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName}: {args.Status}[/]" +
+                    $"[{statusColor}][[{args.CurrentIndex}/{args.TotalCount}]] {args.PackageName.EscapeMarkup()}: {args.Status}[/]" +
                     (args.Message != null ? $" - {args.Message.EscapeMarkup()}" : ""));
             };
 
@@ -71,16 +71,16 @@ public class AurUpgradeCommand : AsyncCommand<AurUpgradeSettings>
                 }
 
                 var showDiff = AnsiConsole.Confirm(
-                    $"[yellow]PKGBUILD changed for {args.PackageName}. View diff?[/]", defaultValue: false);
+                    $"[yellow]PKGBUILD changed for {args.PackageName.EscapeMarkup()}. View diff?[/]", defaultValue: false);
 
                 if (showDiff)
                 {
-                    AnsiConsole.MarkupLine($"[blue]--- PKGBUILD diff for {args.PackageName} ---[/]");
+                    AnsiConsole.MarkupLine($"[blue]--- PKGBUILD diff for {args.PackageName.EscapeMarkup()} ---[/]");
                     PrintUnifiedDiff(args.OldPkgbuild, args.NewPkgbuild);
                 }
 
                 args.ProceedWithUpdate = AnsiConsole.Confirm(
-                    $"[yellow]Proceed with update for {args.PackageName}?[/]", defaultValue: true);
+                    $"[yellow]Proceed with update for {args.PackageName.EscapeMarkup()}?[/]", defaultValue: true);
             };
 
             var packageNames = updates.Select(u => u.Name).ToList();

--- a/Shelly-CLI/Commands/Config/ConfigGetCommand.cs
+++ b/Shelly-CLI/Commands/Config/ConfigGetCommand.cs
@@ -19,7 +19,7 @@ public class ConfigGetCommand : Command<ConfigGetSettings>
         var value = ConfigManager.GetConfigValue(settings.Key);
         if (value == null)
         {
-            AnsiConsole.MarkupLine($"[red]Unknown configuration key: {settings.Key}[/]");
+            AnsiConsole.MarkupLine($"[red]Unknown configuration key: {settings.Key.EscapeMarkup()}[/]");
             return 1;
         }
 

--- a/Shelly-CLI/Commands/Config/ConfigSetCommand.cs
+++ b/Shelly-CLI/Commands/Config/ConfigSetCommand.cs
@@ -23,11 +23,11 @@ public class ConfigSetCommand : Command<ConfigSetSettings>
         var success = ConfigManager.UpdateConfig(settings.Key, settings.Value);
         if (!success)
         {
-            AnsiConsole.MarkupLine($"[red]Failed to set configuration key: {settings.Key}[/]");
+            AnsiConsole.MarkupLine($"[red]Failed to set configuration key: {settings.Key.EscapeMarkup()}[/]");
             return 1;
         }
 
-        AnsiConsole.MarkupLine($"[green]{settings.Key}[/] set to [blue]{settings.Value}[/]");
+        AnsiConsole.MarkupLine($"[green]{settings.Key.EscapeMarkup()}[/] set to [blue]{settings.Value.EscapeMarkup()}[/]");
         return 0;
     }
 }

--- a/Shelly-CLI/Commands/Flatpak/FlatpakAddRemote.cs
+++ b/Shelly-CLI/Commands/Flatpak/FlatpakAddRemote.cs
@@ -12,11 +12,11 @@ public class FlatpakAddRemote :  Command<FlatpakRemoteSettings>
         
         var manager = new FlatpakManager();
 
-        AnsiConsole.MarkupLine($"[blue]Adding remote {settings.RemoteName} [/]");
+        AnsiConsole.MarkupLine($"[blue]Adding remote {settings.RemoteName.EscapeMarkup()} [/]");
         
         var remotes = manager.AddRemote(settings.RemoteName, settings.RemoteUrl, settings.SystemWide, settings.GpgVerify);
         
-        AnsiConsole.MarkupLine($"{remotes}");
+        AnsiConsole.MarkupLine($"{remotes.EscapeMarkup()}");
         
         return 0;
     }

--- a/Shelly-CLI/Commands/Flatpak/FlatpakKillCommand.cs
+++ b/Shelly-CLI/Commands/Flatpak/FlatpakKillCommand.cs
@@ -18,7 +18,7 @@ public class FlatpakKillCommand : Command<FlatpakPackageSettings>
         AnsiConsole.MarkupLine("[yellow]Killing selected flatpak app...[/]");
         var result = new FlatpakManager().KillApp(settings.Packages);
 
-        AnsiConsole.MarkupLine("[red]" + result + "[/]");
+        AnsiConsole.MarkupLine("[red]" + result.EscapeMarkup() + "[/]");
 
         return 0;
     }

--- a/Shelly-CLI/Commands/Flatpak/FlatpakRemoveRemote.cs
+++ b/Shelly-CLI/Commands/Flatpak/FlatpakRemoveRemote.cs
@@ -11,11 +11,11 @@ public class FlatpakRemoveRemote : Command<FlatpakRemoveRemoteSettings>
     {
         var manager = new FlatpakManager();
 
-        AnsiConsole.MarkupLine($"[red]Removing remote {settings.RemoteName} [/]");
+        AnsiConsole.MarkupLine($"[red]Removing remote {settings.RemoteName.EscapeMarkup()} [/]");
 
         var remotes = manager.RemoveRemote(settings.RemoteName, settings.SystemWide);
 
-        AnsiConsole.MarkupLine($"{remotes}");
+        AnsiConsole.MarkupLine($"{remotes.EscapeMarkup()}");
 
         return 0;
     }

--- a/Shelly-CLI/Commands/Flatpak/FlatpakSyncRemoteAppStream.cs
+++ b/Shelly-CLI/Commands/Flatpak/FlatpakSyncRemoteAppStream.cs
@@ -13,11 +13,11 @@ public class FlatpakSyncRemoteAppStream : Command
 
         if (result)
         {
-            AnsiConsole.MarkupLine($"[green]{stringResult}[/]");
+            AnsiConsole.MarkupLine($"[green]{stringResult.EscapeMarkup()}[/]");
             return 0;
         }
 
-        AnsiConsole.MarkupLine($"[red]{stringResult}[/]");
+        AnsiConsole.MarkupLine($"[red]{stringResult.EscapeMarkup()}[/]");
         return 1;
     }
 }

--- a/Shelly-CLI/Commands/Keyring/KeyringLsignCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringLsignCommand.cs
@@ -21,14 +21,14 @@ public class KeyringLsignCommand : Command<KeyringSettings>
             return 1;
         }
 
-        AnsiConsole.MarkupLine($"[yellow]Locally signing keys: {string.Join(", ", settings.Keys)}...[/]");
+        AnsiConsole.MarkupLine($"[yellow]Locally signing keys: {string.Join(", ", settings.Keys.Select(k => k.EscapeMarkup()))}...[/]");
 
         foreach (var key in settings.Keys)
         {
             var result = PacmanKeyRunner.Run($"--lsign-key {key}");
             if (result != 0)
             {
-                AnsiConsole.MarkupLine($"[red]Failed to sign key: {key}[/]");
+                AnsiConsole.MarkupLine($"[red]Failed to sign key: {key.EscapeMarkup()}[/]");
                 return result;
             }
         }

--- a/Shelly-CLI/Commands/Keyring/KeyringPopulateCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringPopulateCommand.cs
@@ -19,7 +19,7 @@ public class KeyringPopulateCommand : Command<KeyringSettings>
         if (settings.Keys?.Length > 0)
         {
             args += " " + string.Join(" ", settings.Keys);
-            AnsiConsole.MarkupLine($"[yellow]Populating keyring with: {string.Join(", ", settings.Keys)}...[/]");
+            AnsiConsole.MarkupLine($"[yellow]Populating keyring with: {string.Join(", ", settings.Keys.Select(k => k.EscapeMarkup()))}...[/]");
         }
         else
         {

--- a/Shelly-CLI/Commands/Keyring/KeyringRecvCommand.cs
+++ b/Shelly-CLI/Commands/Keyring/KeyringRecvCommand.cs
@@ -27,7 +27,7 @@ public class KeyringRecvCommand : Command<KeyringSettings>
             args += $" --keyserver {settings.Keyserver}";
         }
 
-        AnsiConsole.MarkupLine($"[yellow]Receiving keys: {string.Join(", ", settings.Keys)}...[/]");
+        AnsiConsole.MarkupLine($"[yellow]Receiving keys: {string.Join(", ", settings.Keys.Select(k => k.EscapeMarkup()))}...[/]");
         var result = PacmanKeyRunner.Run(args);
         if (result == 0)
         {

--- a/Shelly-CLI/Commands/Standard/AppImageInstallCommand.cs
+++ b/Shelly-CLI/Commands/Standard/AppImageInstallCommand.cs
@@ -98,7 +98,7 @@ public class AppImageInstallCommand : AsyncCommand<AppImageInstallSettings>
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set file permissions: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set file permissions: {ex.Message.EscapeMarkup()}[/]");
         }
     }
 
@@ -133,11 +133,11 @@ public class AppImageInstallCommand : AsyncCommand<AppImageInstallSettings>
             SetFilePermissions(desktopFilePath, "644");
             UpdateDesktopDatabase(desktopDir);
 
-            AnsiConsole.MarkupLine($"[green]Desktop entry created: {desktopFilePath}[/]");
+            AnsiConsole.MarkupLine($"[green]Desktop entry created: {desktopFilePath.EscapeMarkup()}[/]");
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not create desktop entry: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not create desktop entry: {ex.Message.EscapeMarkup()}[/]");
         }
     }
 
@@ -166,7 +166,7 @@ public class AppImageInstallCommand : AsyncCommand<AppImageInstallSettings>
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set desktop database: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set desktop database: {ex.Message.EscapeMarkup()}[/]");
         }
     }
 }

--- a/Shelly-CLI/Commands/Standard/DowngradePackageCommand.cs
+++ b/Shelly-CLI/Commands/Standard/DowngradePackageCommand.cs
@@ -28,7 +28,7 @@ public class DowngradePackageCommand : Command<DowngradePackageCommandSettings>
 
         RootElevator.EnsureRootExectuion();
         var package = settings.Packages[0];
-        AnsiConsole.MarkupLine($"[yellow]Looking for downgrade options for:[/]: {package}");
+        AnsiConsole.MarkupLine($"[yellow]Looking for downgrade options for:[/]: {package.EscapeMarkup()}");
 
         var manager = new AlpmManager();
         manager.Initialize(true);
@@ -56,7 +56,7 @@ public class DowngradePackageCommand : Command<DowngradePackageCommandSettings>
         var filePath = Path.Combine(Path.GetTempPath(), fileName);
 
         AnsiConsole.Status()
-            .Start($"[yellow]Downloading {fileName}...[/]", ctx =>
+            .Start($"[yellow]Downloading {fileName.EscapeMarkup()}...[/]", ctx =>
             {
                 using var response = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).Result;
                 response.EnsureSuccessStatusCode();
@@ -65,7 +65,7 @@ public class DowngradePackageCommand : Command<DowngradePackageCommandSettings>
                 response.Content.ReadAsStream().CopyTo(fs);
             });
 
-        AnsiConsole.MarkupLine($"[green]Downloaded to {filePath}[/]");
+        AnsiConsole.MarkupLine($"[green]Downloaded to {filePath.EscapeMarkup()}[/]");
 
         if (!AnsiConsole.Confirm("Do you want to proceed with the installation?"))
         {

--- a/Shelly-CLI/Commands/Standard/InstallCommand.cs
+++ b/Shelly-CLI/Commands/Standard/InstallCommand.cs
@@ -25,7 +25,7 @@ public class InstallCommand : AsyncCommand<InstallPackageSettings>
 
         var packageList = settings.Packages.ToList();
 
-        AnsiConsole.MarkupLine($"[yellow]Packages to install:[/] {string.Join(", ", packageList)}");
+        AnsiConsole.MarkupLine($"[yellow]Packages to install:[/] {string.Join(", ", packageList.Select(p => p.EscapeMarkup()))}");
 
         if (!AnsiConsole.Confirm("Do you want to proceed?"))
         {

--- a/Shelly-CLI/Commands/Standard/InstallLocalPackageCommand.cs
+++ b/Shelly-CLI/Commands/Standard/InstallLocalPackageCommand.cs
@@ -148,7 +148,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             }
         }
 
-        AnsiConsole.MarkupLine($"[green]Extracted to {installDir}[/]");
+        AnsiConsole.MarkupLine($"[green]Extracted to {installDir.EscapeMarkup()}[/]");
 
         foreach (var binaryName in installedBinaries)
         {
@@ -158,7 +158,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             {
                 if (foundIcons.Count > 0)
                 {
-                    AnsiConsole.MarkupLine($"[cyan]Found icon for {binaryName}: {foundIcons.FirstOrDefault().Key}[/]");
+                    AnsiConsole.MarkupLine($"[cyan]Found icon for {binaryName.EscapeMarkup()}: {foundIcons.FirstOrDefault().Key.EscapeMarkup()}[/]");
                     var installedIconName = InstallIcon(foundIcons.FirstOrDefault().Value, binaryName);
                     if (installedIconName != null)
                     {
@@ -167,7 +167,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine($"[yellow]No icon found for {binaryName}, using default[/]");
+                    AnsiConsole.MarkupLine($"[yellow]No icon found for {binaryName.EscapeMarkup()}, using default[/]");
                 }
 
                 Console.WriteLine("Creating desktop entry...");
@@ -357,11 +357,11 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             SetFilePermissions(desktopFilePath, "644");
             UpdateDesktopDatabase(desktopDir);
 
-            AnsiConsole.MarkupLine($"[green]Desktop entry created: {desktopFilePath}[/]");
+            AnsiConsole.MarkupLine($"[green]Desktop entry created: {desktopFilePath.EscapeMarkup()}[/]");
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not create desktop entry: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not create desktop entry: {ex.Message.EscapeMarkup()}[/]");
         }
     }
 
@@ -390,7 +390,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set file permissions: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set file permissions: {ex.Message.EscapeMarkup()}[/]");
         }
     }
 
@@ -411,7 +411,7 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set desktop database: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not set desktop database: {ex.Message.EscapeMarkup()}[/]");
         }
     }
 
@@ -455,14 +455,14 @@ public class InstallLocalPackageCommand : AsyncCommand<InstallLocalPackageSettin
             }
             catch (Exception ex)
             {
-                AnsiConsole.MarkupLine($"[yellow]Warning: Failed to update icon cache: {ex.Message}[/]");
+                AnsiConsole.MarkupLine($"[yellow]Warning: Failed to update icon cache: {ex.Message.EscapeMarkup()}[/]");
             }
 
             return appName.ToLower();
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[yellow]Warning: Could not install icon: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Warning: Could not install icon: {ex.Message.EscapeMarkup()}[/]");
             return null;
         }
     }

--- a/Shelly-CLI/Commands/Standard/PackageInformationCommand.cs
+++ b/Shelly-CLI/Commands/Standard/PackageInformationCommand.cs
@@ -40,27 +40,27 @@ public class PackageInformationCommand : Command<PackageInformationSettings>
 
         if (package is null)
         {
-            AnsiConsole.MarkupLine($"[red]No package named {settings.Packages[0]} found[/]");
+            AnsiConsole.MarkupLine($"[red]No package named {settings.Packages[0].EscapeMarkup()} found[/]");
             return 0;
         }
 
-        WriteLeftAlignMarkup($"[green]Name: {package.Name}[/]");
-        WriteLeftAlignMarkup($"[blue]Version {package.Version}[/]");
-        WriteLeftAlignMarkup($"[blue]Description: {package.Description}[/]");
-        WriteLeftAlignMarkup($"[blue]URL: {package.Url}[/]");
-        WriteLeftAlignMarkup($"[blue]Licenses: {string.Join(',', package.Licenses)}[/]");
-        WriteLeftAlignMarkup($"[blue]Groups: {string.Join(',', package.Groups)}[/]");
-        WriteLeftAlignMarkup($"[blue]Provides: {string.Join(',', package.Provides)}[/]");
-        WriteLeftAlignMarkup($"[blue]Depends On: {string.Join(',', package.Depends)}[/]");
-        WriteLeftAlignMarkup($"[blue]Optional Depends: {string.Join(',', package.OptDepends)}[/]");
-        WriteLeftAlignMarkup($"[blue]Required By: {string.Join(',', package.RequiredBy)}[/]");
-        WriteLeftAlignMarkup($"[blue]Conflicts With: {string.Join(',', package.Conflicts)}[/]");
-        WriteLeftAlignMarkup($"[blue]Replaces: {string.Join(',', package.Replaces)}[/]");
+        WriteLeftAlignMarkup($"[green]Name: {package.Name.EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Version {package.Version.EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Description: {package.Description.EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]URL: {package.Url.EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Licenses: {string.Join(',', package.Licenses).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Groups: {string.Join(',', package.Groups).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Provides: {string.Join(',', package.Provides).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Depends On: {string.Join(',', package.Depends).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Optional Depends: {string.Join(',', package.OptDepends).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Required By: {string.Join(',', package.RequiredBy).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Conflicts With: {string.Join(',', package.Conflicts).EscapeMarkup()}[/]");
+        WriteLeftAlignMarkup($"[blue]Replaces: {string.Join(',', package.Replaces).EscapeMarkup()}[/]");
         WriteLeftAlignMarkup($"[blue]Installed Size:{package.InstalledSize} bytes[/]");
         var installDate = package.InstallDate.HasValue
             ? package.InstallDate.Value.ToLongDateString()
             : "Not Installed";
-        WriteLeftAlignMarkup($"[blue]Install Date: {installDate}[/]");
+        WriteLeftAlignMarkup($"[blue]Install Date: {installDate.EscapeMarkup()}[/]");
         WriteLeftAlignMarkup($"[blue]Install Reason: {package.InstallReason}[/]");
         return 0;
     }

--- a/Shelly-CLI/Commands/Standard/RemoveCommand.cs
+++ b/Shelly-CLI/Commands/Standard/RemoveCommand.cs
@@ -24,7 +24,7 @@ public class RemoveCommand : AsyncCommand<RemovePackageSettings>
         RootElevator.EnsureRootExectuion();
         var packageList = settings.Packages.ToList();
 
-        AnsiConsole.MarkupLine($"[yellow]Packages to remove:[/] {string.Join(", ", packageList)}");
+        AnsiConsole.MarkupLine($"[yellow]Packages to remove:[/] {string.Join(", ", packageList.Select(p => p.EscapeMarkup()))}");
 
         if (!Program.IsUiMode)
         {

--- a/Shelly-CLI/Commands/Standard/UpdateCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpdateCommand.cs
@@ -21,7 +21,7 @@ public class UpdateCommand : Command<PackageSettings>
 
         var packageList = settings.Packages.ToList();
 
-        AnsiConsole.MarkupLine($"[yellow]Packages to update:[/] {string.Join(", ", packageList)}");
+        AnsiConsole.MarkupLine($"[yellow]Packages to update:[/] {string.Join(", ", packageList.Select(p => p.EscapeMarkup()))}");
 
         if (!Program.IsUiMode)
         {

--- a/Shelly-CLI/Commands/Utility/Export.cs
+++ b/Shelly-CLI/Commands/Utility/Export.cs
@@ -62,7 +62,7 @@ public class Export : AsyncCommand<ExportSettings>
 
         await File.WriteAllTextAsync(path, json);
 
-        AnsiConsole.MarkupLine($"[blue]Sync file exported to: {path}[/]");
+        AnsiConsole.MarkupLine($"[blue]Sync file exported to: {path.EscapeMarkup()}[/]");
 
         return 0;
     }


### PR DESCRIPTION
…iConsole.MarkupLine`.