### PR TITLE
Add library availability check in `GetPackagesWithUpdates` to prevent…

### DIFF
--- a/PackageManager/Flatpak/FlatpakManager.cs
+++ b/PackageManager/Flatpak/FlatpakManager.cs
@@ -1400,6 +1400,11 @@ public class FlatpakManager : IDisposable
     /// </summary>
     public List<FlatpakPackageDto> GetPackagesWithUpdates()
     {
+        if (!NativeResolver.IsLibraryAvailable(FlatpakReference.LibName))
+        {
+            return [];
+        }
+
         var packages = new List<FlatpakPackageDto>();
 
         var installationsPtr = FlatpakReference.GetSystemInstallations(IntPtr.Zero, out IntPtr error);


### PR DESCRIPTION
… errors when Flatpak library is not loaded