### PR TITLE
Fix AppImage installation for case-insensitive extensions

### DIFF
--- a/Shelly-CLI/Commands/Standard/AppImageInstallCommand.cs
+++ b/Shelly-CLI/Commands/Standard/AppImageInstallCommand.cs
@@ -53,14 +53,13 @@ public class AppImageInstallCommand : AsyncCommand<AppImageInstallSettings>
         var installDir = Path.Combine("/opt/shelly");
         Directory.CreateDirectory(installDir);
 
-        var destPath = Path.Combine(installDir, Path.GetFileName(filePath));
+        var appName = Path.GetFileNameWithoutExtension(filePath);
+        var destPath = Path.Combine(installDir, appName + ".AppImage");
         File.Copy(filePath, destPath, overwrite: true);
         AnsiConsole.MarkupLine($"[green]Copied appimage to: {destPath.EscapeMarkup()}[/]");
 
         SetFilePermissions(destPath, "a+x");
         AnsiConsole.MarkupLine($"[green]Setting file permissions to: a+x[/]");
-
-        var appName = Path.GetFileNameWithoutExtension(filePath);
 
         Console.WriteLine("Creating desktop entry...");
         CreateDesktopEntry(
@@ -78,7 +77,7 @@ public class AppImageInstallCommand : AsyncCommand<AppImageInstallSettings>
     private static Task<bool> IsAppImage(string filePath)
     {
         var extension = Path.GetExtension(filePath);
-        return Task.FromResult(extension == ".AppImage");
+        return Task.FromResult(string.Equals(extension, ".AppImage", StringComparison.OrdinalIgnoreCase));
     }
 
     private static void SetFilePermissions(string filePath, string permissions)


### PR DESCRIPTION
I noticed that the installation of an AppImage failed when the file was provided with a lowercase extension (e.g., .appimage).

This PR includes the following changes:
- Makes the .AppImage extension validation case-insensitive.
- Normalizes the installed file's extension to .AppImage to prevent duplicate installations of the same app with differently cased file extensions.