### PR TITLE
Add restart management for system services and reboot detection after…

### DIFF
--- a/PackageManager/Utilities/RestartManager.cs
+++ b/PackageManager/Utilities/RestartManager.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace PackageManager.Utilities;
+
+public static class RestartManager
+{
+    public static (bool needsReboot, List<string> servicesNeedingRestart) CheckForRequiredRestarts()
+    {
+        HashSet<string> servicesNeedingRestart = [];
+        var runningKernel = File.ReadAllText("/proc/sys/kernel/osrelease").Trim();
+        var needsReboot = !Directory.Exists($"/usr/lib/modules/{runningKernel}");
+
+        foreach (var process in Directory.GetDirectories("/proc"))
+        {
+            var pid = Path.GetFileName(process);
+            if (!int.TryParse(pid, out _))
+            {
+                continue;
+            }
+
+            var mapsFile = Path.Combine(process, "maps");
+            if (!File.Exists(mapsFile))
+            {
+                continue;
+            }
+
+            try
+            {
+                var maps = File.ReadAllText(mapsFile);
+                if (!maps.Contains("(deleted)") || !maps.Contains(".so"))
+                {
+                    continue;
+                }
+
+                var cgroupFile = Path.Combine(process, "cgroup");
+                if (!File.Exists(cgroupFile))
+                {
+                    continue;
+                }
+
+                var cgroup = File.ReadAllText(cgroupFile);
+                var match = Regex.Match(
+                    cgroup, @"/system\.slice/(.+\.service)");
+                if (match.Success)
+                {
+                    servicesNeedingRestart.Add(match.Groups[1].Value);
+                }
+
+                var commFile = Path.Combine(process, "comm");
+                if (File.Exists(commFile))
+                {
+                    var comm = File.ReadAllText(commFile).Trim();
+                    if (comm is "systemd" or "dbus-daemon" or "dbus-broker")
+                        needsReboot = true;
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+        }
+
+        return (needsReboot, servicesNeedingRestart.ToList());
+    }
+
+    public static async Task<List<(string service, string error)>> RestartServicesAsync(List<string> services)
+    {
+        var failures = new List<(string service, string error)>();
+        foreach (var svc in services)
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "systemctl",
+                    Arguments = $"restart {svc}",
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            var stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            if (process.ExitCode != 0)
+                failures.Add((svc, stderr.Trim()));
+        }
+        return failures;
+    }
+}

--- a/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpgradeCommand.cs
@@ -1,4 +1,5 @@
 using PackageManager.Alpm;
+using PackageManager.Utilities;
 using Shelly_CLI.Commands.Aur;
 using Shelly_CLI.Commands.Flatpak;
 using Shelly_CLI.Configuration;
@@ -125,6 +126,27 @@ public class UpgradeCommand : AsyncCommand<UpgradeSettings>
             flatpakCommand.Execute(context);
         }
 
+        var (needsReboot, services) = RestartManager.CheckForRequiredRestarts();
+        if (needsReboot)
+        {
+            AnsiConsole.MarkupLine("[bold red]⚠ A full system reboot is required![/]");
+        }
+        else if (services.Count > 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]Restarting services...[/]");
+            var failures = await RestartManager.RestartServicesAsync(services);
+            if (failures.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[green]All services restarted successfully.[/]");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[bold red] The following services failed to restart:[/]");
+                foreach (var (svc, error) in failures)
+                    AnsiConsole.MarkupLine($"[red]  • {Markup.Escape(svc)}: {Markup.Escape(error)}[/]");
+            }
+        }
+
         return 0;
     }
 
@@ -216,6 +238,18 @@ public class UpgradeCommand : AsyncCommand<UpgradeSettings>
         {
             var flatpakCommand = new FlatpakUpgrade();
             flatpakCommand.Execute(context);
+        }
+
+        var (needsReboot, services) = RestartManager.CheckForRequiredRestarts();
+        if (needsReboot)
+        {
+            await Console.Error.WriteLineAsync("[RESTART_REQUIRED]reboot");
+        }
+        else if (services.Count > 0)
+        {
+            var failures = await RestartManager.RestartServicesAsync(services);
+            foreach (var (svc, error) in failures)
+                await Console.Error.WriteLineAsync($"[RESTART_FAILED]service:{svc}|{error}");
         }
 
         await Console.Error.WriteLineAsync("System upgraded successfully!");

--- a/Shelly.Gtk/Services/IPrivilegedOperationService.cs
+++ b/Shelly.Gtk/Services/IPrivilegedOperationService.cs
@@ -38,4 +38,6 @@ public class OperationResult
     public string Output { get; init; } = string.Empty;
     public string Error { get; init; } = string.Empty;
     public int ExitCode { get; init; }
+    public bool NeedsReboot { get; set; }
+    public List<(string Service, string Error)> FailedServiceRestarts { get; set; } = [];
 }

--- a/Shelly.Gtk/Services/PrivilegedOperationService.cs
+++ b/Shelly.Gtk/Services/PrivilegedOperationService.cs
@@ -646,6 +646,10 @@ public class PrivilegedOperationService : IPrivilegedOperationService
         string? conflictQuestion = null;
         var awaitingConflictSelection = false;
 
+        // State for restart check results
+        var restartNeedsReboot = false;
+        var restartFailures = new List<(string Service, string Error)>();
+
         process.OutputDataReceived += (sender, e) =>
         {
             if (e.Data != null)
@@ -891,6 +895,24 @@ public class PrivilegedOperationService : IPrivilegedOperationService
                                 await SafeWriteAsync(args.Response == 1 ? "y" : "n");
                             }
                         }
+                        else if (e.Data.StartsWith("[Shelly][RESTART_REQUIRED]"))
+                        {
+                            var payload = e.Data.Substring("[Shelly][RESTART_REQUIRED]".Length);
+                            if (payload == "reboot")
+                                restartNeedsReboot = true;
+                        }
+                        else if (e.Data.StartsWith("[Shelly][RESTART_FAILED]"))
+                        {
+                            var payload = e.Data.Substring("[Shelly][RESTART_FAILED]".Length);
+                            if (payload.StartsWith("service:"))
+                            {
+                                var rest = payload.Substring("service:".Length);
+                                var parts = rest.Split('|', 2);
+                                var svcName = parts[0];
+                                var svcError = parts.Length > 1 ? parts[1] : "Unknown error";
+                                restartFailures.Add((svcName, svcError));
+                            }
+                        }
                         else if (e.Data.StartsWith("[Shelly][DEBUG]"))
                         {
                             // Debug messages - skip, don't forward to lockout dialog
@@ -974,7 +996,9 @@ public class PrivilegedOperationService : IPrivilegedOperationService
                 Success = success,
                 Output = outputBuilder.ToString(),
                 Error = errorBuilder.ToString(),
-                ExitCode = process.ExitCode
+                ExitCode = process.ExitCode,
+                NeedsReboot = restartNeedsReboot,
+                FailedServiceRestarts = restartFailures
             };
         }
         catch (Exception ex)

--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -283,8 +283,34 @@ public class HomeWindow(
                 }
             }
 
-            await privilegedOperationService.UpgradeAllAsync();
+            var upgradeResult = await privilegedOperationService.UpgradeAllAsync();
             await ReloadHomePageData();
+
+            if (upgradeResult.NeedsReboot)
+            {
+                var rebootArgs = new GenericQuestionEventArgs(
+                    "Reboot Required",
+                    "A full system reboot is required for updates to take effect.\n\nWould you like to reboot now?",
+                    true
+                );
+                genericQuestionService.RaiseQuestion(rebootArgs);
+                if (await rebootArgs.ResponseTask)
+                {
+                    System.Diagnostics.Process.Start("systemctl", "reboot");
+                }
+            }
+            else if (upgradeResult.FailedServiceRestarts.Count > 0)
+            {
+                var failureList = string.Join("\n", upgradeResult.FailedServiceRestarts
+                    .Select(f => $"  • {f.Service}: {f.Error}"));
+                var failArgs = new GenericQuestionEventArgs(
+                    "Service Restart Failures",
+                    $"The following services failed to restart automatically:\n{failureList}",
+                    false
+                );
+                genericQuestionService.RaiseQuestion(failArgs);
+                await failArgs.ResponseTask;
+            }
         }
         catch (Exception e)
         {

--- a/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
@@ -488,12 +488,39 @@ public class PackageUpdate(
             try
             {
                 lockoutService.Show($"Updating...");
+                OperationResult upgradeResult;
                 if (isFullUpgrade)
-                    await privilegedOperationService.UpgradeSystemAsync();
+                    upgradeResult = await privilegedOperationService.UpgradeSystemAsync();
                 else
-                    await privilegedOperationService.UpdatePackagesAsync(selectedPackages);
+                    upgradeResult = await privilegedOperationService.UpdatePackagesAsync(selectedPackages);
 
                 await LoadDataAsync();
+
+                if (upgradeResult.NeedsReboot)
+                {
+                    var rebootArgs = new GenericQuestionEventArgs(
+                        "Reboot Required",
+                        "A full system reboot is required for updates to take effect.\n\nWould you like to reboot now?",
+                        true
+                    );
+                    genericQuestionService.RaiseQuestion(rebootArgs);
+                    if (await rebootArgs.ResponseTask)
+                    {
+                        System.Diagnostics.Process.Start("systemctl", "reboot");
+                    }
+                }
+                else if (upgradeResult.FailedServiceRestarts.Count > 0)
+                {
+                    var failureList = string.Join("\n", upgradeResult.FailedServiceRestarts
+                        .Select(f => $"  • {f.Service}: {f.Error}"));
+                    var failArgs = new GenericQuestionEventArgs(
+                        "Service Restart Failures",
+                        $"The following services failed to restart automatically:\n{failureList}",
+                        false
+                    );
+                    genericQuestionService.RaiseQuestion(failArgs);
+                    await failArgs.ResponseTask;
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
… upgrades

- Introduce `RestartManager` to detect required service restarts or system reboots.
- Notify users of reboot requirements and failed service restarts in both CLI and GUI.
- Implement async service restart handling and failure reporting.
- Update GUI workflows to prompt for reboots or display errors for failed service restarts.