### PR TITLE
Add VCS source parsing and update tracking for AUR packages

### DIFF
--- a/PackageManager.Tests/Aur/VcsSourceParserTests.cs
+++ b/PackageManager.Tests/Aur/VcsSourceParserTests.cs
@@ -1,0 +1,96 @@
+using PackageManager.Aur;
+
+namespace PackageManager.Tests.Aur;
+
+public class VcsSourceParserTests
+{
+    [Test]
+    public void ParseSource_GitPlusHttps_ReturnsEntry()
+    {
+        var result = VcsSourceParser.ParseSource("git+https://github.com/user/repo.git");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Url, Is.EqualTo("https://github.com/user/repo.git"));
+        Assert.That(result.Branch, Is.EqualTo("HEAD"));
+        Assert.That(result.Protocols, Does.Contain("https"));
+        Assert.That(result.Protocols, Does.Not.Contain("git"));
+    }
+
+    [Test]
+    public void ParseSource_WithNamePrefix_StripsName()
+    {
+        var result = VcsSourceParser.ParseSource("myrepo::git+https://github.com/user/repo.git");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Url, Is.EqualTo("https://github.com/user/repo.git"));
+    }
+
+    [Test]
+    public void ParseSource_WithBranchFragment_ParsesBranch()
+    {
+        var result = VcsSourceParser.ParseSource("git+https://github.com/user/repo.git#branch=develop");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Url, Is.EqualTo("https://github.com/user/repo.git"));
+        Assert.That(result.Branch, Is.EqualTo("develop"));
+    }
+
+    [Test]
+    public void ParseSource_WithCommitFragment_ReturnsNull()
+    {
+        var result = VcsSourceParser.ParseSource("git+https://github.com/user/repo.git#commit=abc123");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ParseSource_WithTagFragment_ReturnsNull()
+    {
+        var result = VcsSourceParser.ParseSource("git+https://github.com/user/repo.git#tag=v1.0");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ParseSource_NonGitSource_ReturnsNull()
+    {
+        var result = VcsSourceParser.ParseSource("https://example.com/archive.tar.gz");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ParseSource_WithQueryParams_StripsQuery()
+    {
+        var result = VcsSourceParser.ParseSource("git+https://github.com/user/repo.git?signed");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Url, Is.EqualTo("https://github.com/user/repo.git"));
+    }
+
+    [Test]
+    public void ParseSource_EmptyString_ReturnsNull()
+    {
+        Assert.That(VcsSourceParser.ParseSource(""), Is.Null);
+        Assert.That(VcsSourceParser.ParseSource("   "), Is.Null);
+    }
+
+    [Test]
+    public void ParseSources_MixedSources_ReturnsOnlyGit()
+    {
+        var sources = new[]
+        {
+            "git+https://github.com/user/repo.git",
+            "https://example.com/archive.tar.gz",
+            "git+https://github.com/user/repo2.git#commit=abc",
+            "myname::git+https://github.com/user/repo3.git#branch=main"
+        };
+
+        var results = VcsSourceParser.ParseSources(sources);
+        Assert.That(results, Has.Count.EqualTo(2));
+        Assert.That(results[0].Url, Is.EqualTo("https://github.com/user/repo.git"));
+        Assert.That(results[1].Url, Is.EqualTo("https://github.com/user/repo3.git"));
+        Assert.That(results[1].Branch, Is.EqualTo("main"));
+    }
+
+    [Test]
+    public void ParseSource_NamedWithColonColon_HandlesCorrectly()
+    {
+        var result = VcsSourceParser.ParseSource("pkg-name::git+https://gitlab.com/org/project.git");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Url, Is.EqualTo("https://gitlab.com/org/project.git"));
+    }
+}

--- a/PackageManager/Aur/AurPackageManager.cs
+++ b/PackageManager/Aur/AurPackageManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using PackageManager.Alpm;
 using PackageManager.Alpm.Events.EventArgs;
@@ -66,6 +67,7 @@ public class AurPackageManager(string? configPath = null)
     private bool _useChroot = false;
     private bool _noCheck = true;
     private string _chrootPath;
+    private readonly VcsInfoStore _vcsInfoStore = new();
 
     public event EventHandler<PackageProgressEventArgs>? PackageProgress;
     public event EventHandler<PkgbuildDiffRequestEventArgs>? PkgbuildDiffRequest;
@@ -102,6 +104,7 @@ public class AurPackageManager(string? configPath = null)
         _noCheck = noCheck;
         // Import caches from other AUR helpers (paru, yay) for installed foreign packages
         await ImportOtherAurHelperCaches();
+        await _vcsInfoStore.Load();
     }
 
     public async Task<List<AurPackageDto>> GetInstalledPackages()
@@ -132,11 +135,14 @@ public class AurPackageManager(string? configPath = null)
         return infoResponse.Results ?? [];
     }
 
-    public async Task<List<AurUpdateDto>> GetPackagesNeedingUpdate()
+    public async Task<List<AurUpdateDto>> GetPackagesNeedingUpdate(bool checkDevel = true)
     {
         List<AurUpdateDto> packagesToUpdate = [];
         var packages = _alpm.GetForeignPackages();
         var response = await _aurSearchManager.GetInfoAsync(packages.Select(x => x.Name).ToList());
+
+        var aurUpdateNames = new HashSet<string>();
+
         foreach (var pkg in response.Results)
         {
             var installedPkg = packages.FirstOrDefault(x => x.Name == pkg.Name);
@@ -144,6 +150,7 @@ public class AurPackageManager(string? configPath = null)
             {
                 continue;
             }
+
             if (VersionComparer.IsNewer(pkg.Version, installedPkg.Version))
             {
                 packagesToUpdate.Add(new AurUpdateDto
@@ -155,9 +162,49 @@ public class AurPackageManager(string? configPath = null)
                     PackageBase = pkg.PackageBase,
                     Description = pkg.Description ?? string.Empty
                 });
+                aurUpdateNames.Add(pkg.Name);
             }
         }
 
+        if (!checkDevel)
+        {
+            return packagesToUpdate;
+        }
+
+        var vcsPackages = packages.Where(p => IsVcsPackage(p.Name) && !aurUpdateNames.Contains(p.Name)).ToList();
+        var semaphore = new SemaphoreSlim(15);
+        var vcsResults = await Task.WhenAll(vcsPackages.Select(async installedPkg =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                var needsUpdate = await CheckVcsPackageNeedsUpdate(installedPkg.Name);
+                if (!needsUpdate)
+                    return null;
+
+                var aurInfo = response.Results.FirstOrDefault(x => x.Name == installedPkg.Name);
+                return new AurUpdateDto
+                {
+                    Name = installedPkg.Name,
+                    Version = installedPkg.Version,
+                    NewVersion = "latest-commit",
+                    Url = aurInfo?.Url ?? string.Empty,
+                    PackageBase = aurInfo?.PackageBase ?? installedPkg.Name,
+                    Description = aurInfo?.Description ?? string.Empty
+                };
+            }
+            catch (Exception ex)
+            {
+                await Console.Error.WriteLineAsync($"Error checking version for {installedPkg.Name}: {ex.Message}");
+                return null;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }));
+
+        packagesToUpdate.AddRange(vcsResults.Where(r => r != null)!);
         return packagesToUpdate;
     }
 
@@ -493,6 +540,7 @@ public class AurPackageManager(string? configPath = null)
                 {
                     return;
                 }
+
                 BuildOutput?.Invoke(this, new BuildOutputEventArgs
                 {
                     PackageName = packageName,
@@ -545,8 +593,11 @@ public class AurPackageManager(string? configPath = null)
 
             try
             {
-                _ =_alpm.InstallLocalPackage(pkgFiles[0]).Result;
+                _ = _alpm.InstallLocalPackage(pkgFiles[0]).Result;
                 _alpm.Refresh();
+
+                // Update VCS info store with current commit SHAs after successful install
+                await UpdateVcsStoreForPackage(packageName, System.IO.Path.Combine(tempPath, "PKGBUILD"));
             }
             catch (Exception ex)
             {
@@ -570,7 +621,8 @@ public class AurPackageManager(string? configPath = null)
                     CurrentIndex = i + 1,
                     TotalCount = totalCount,
                     Status = PackageProgressStatus.CleaningUp,
-                    Message = $"Removing {buildOnlyDeps.Count} build-only dependencies: {string.Join(", ", buildOnlyDeps)}"
+                    Message =
+                        $"Removing {buildOnlyDeps.Count} build-only dependencies: {string.Join(", ", buildOnlyDeps)}"
                 });
                 foreach (var dep in buildOnlyDeps)
                 {
@@ -581,6 +633,7 @@ public class AurPackageManager(string? configPath = null)
                         IsError = false
                     });
                 }
+
                 try
                 {
                     _alpm.RemovePackages(buildOnlyDeps, AlpmTransFlag.None);
@@ -614,6 +667,7 @@ public class AurPackageManager(string? configPath = null)
         _alpm.RemovePackages(packageNames, flags);
         foreach (var packageName in packageNames)
         {
+            _vcsInfoStore.RemovePackage(packageName);
             // Clean up cache folder
             var user = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
             var home = $"/home/{user}";
@@ -638,6 +692,8 @@ public class AurPackageManager(string? configPath = null)
                 await rmProcess.WaitForExitAsync();
             }
         }
+
+        await _vcsInfoStore.Save();
     }
 
     public void Dispose()
@@ -742,6 +798,7 @@ public class AurPackageManager(string? configPath = null)
             {
                 return;
             }
+
             BuildOutput?.Invoke(this, new BuildOutputEventArgs
             {
                 PackageName = packageName,
@@ -813,6 +870,7 @@ public class AurPackageManager(string? configPath = null)
                     IsError = false
                 });
             }
+
             try
             {
                 _alpm.RemovePackages(buildOnlyDeps, AlpmTransFlag.None);
@@ -1002,7 +1060,7 @@ public class AurPackageManager(string? configPath = null)
             return false;
         }
     }
-    
+
     /// <summary>
     /// Imports cached AUR package data from other AUR helpers (paru and yay) into Shelly's cache.
     /// This allows Shelly to show PKGBUILD diffs for packages that were originally installed via paru or yay.
@@ -1145,11 +1203,13 @@ public class AurPackageManager(string? configPath = null)
             .ToList();
         var depsToInstall = allDeps.Where(x => !_alpm.IsDependencySatisfiedByInstalled(x.ToString())).ToList();
         var satisfiedDeps = allDeps.Where(x => _alpm.IsDependencySatisfiedByInstalled(x.ToString())).ToList();
-        Console.Error.WriteLine($"[DEBUG] Total deps: {allDeps.Count}, Satisfied: {satisfiedDeps.Count}, To install: {depsToInstall.Count}");
+        Console.Error.WriteLine(
+            $"[DEBUG] Total deps: {allDeps.Count}, Satisfied: {satisfiedDeps.Count}, To install: {depsToInstall.Count}");
         foreach (var dep in satisfiedDeps)
         {
             Console.Error.WriteLine($"[DEBUG] Already satisfied: {dep}");
         }
+
         var alpmPackages = new List<string>();
         var aurPackages = new List<ParsedDependency>();
 
@@ -1339,7 +1399,8 @@ public class AurPackageManager(string? configPath = null)
         List<ParsedDependency> orderedAurPackages,
         AlpmTransFlag flags = AlpmTransFlag.None)
     {
-        Console.Error.WriteLine($"[Shelly] Installing collected dependencies: {allRepoPackages.Count} repo, {orderedAurPackages.Count} AUR");
+        Console.Error.WriteLine(
+            $"[Shelly] Installing collected dependencies: {allRepoPackages.Count} repo, {orderedAurPackages.Count} AUR");
         if (allRepoPackages.Count > 0)
         {
             _alpm.Refresh();
@@ -1574,7 +1635,8 @@ public class AurPackageManager(string? configPath = null)
         }
 
         var user = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
-        var path = Environment.GetEnvironmentVariable("PATH") ?? "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin";
+        var path = Environment.GetEnvironmentVariable("PATH") ??
+                   "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin";
         if (!path.Contains("core_perl"))
             path = $"/usr/bin/core_perl:/usr/bin/vendor_perl:/usr/bin/site_perl:{path}";
 
@@ -1593,5 +1655,159 @@ public class AurPackageManager(string? configPath = null)
         };
         process.StartInfo.Environment["PATH"] = path;
         return process;
+    }
+
+    /// <summary>
+    /// Checks if a VCS package needs an update by comparing stored commit SHAs
+    /// with remote SHAs via git ls-remote (matching yay/paru behavior).
+    /// </summary>
+    private async Task<bool> CheckVcsPackageNeedsUpdate(string packageName)
+    {
+        var storedEntries = _vcsInfoStore.GetEntries(packageName);
+
+        // If we have no stored entries, we need to populate them first from the PKGBUILD
+        if (storedEntries == null || storedEntries.Count == 0)
+        {
+            var entries = await GetVcsSourceEntriesForPackage(packageName);
+            if (entries == null || entries.Count == 0)
+                return false;
+
+            // Populate the store with current remote SHAs so next check can compare
+            foreach (var entry in entries)
+            {
+                var sha = await GetRemoteCommitSha(entry.Url, entry.Branch);
+                if (sha != null)
+                    entry.CommitSha = sha;
+            }
+
+            _vcsInfoStore.SetEntries(packageName, entries);
+            await _vcsInfoStore.Save();
+            return false; // First time seeing this package, don't flag as update
+        }
+
+        // Compare stored SHAs with remote SHAs
+        foreach (var entry in storedEntries)
+        {
+            if (string.IsNullOrEmpty(entry.CommitSha))
+                continue;
+
+            var remoteSha = await GetRemoteCommitSha(entry.Url, entry.Branch);
+            if (remoteSha != null && remoteSha != entry.CommitSha)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Parses the PKGBUILD for a package and returns its trackable git source entries.
+    /// </summary>
+    private async Task<List<VcsSourceEntry>?> GetVcsSourceEntriesForPackage(string packageName)
+    {
+        var user = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
+        var home = $"/home/{user}";
+        var cachePath = Path.Combine(home, ".cache", "Shelly", packageName);
+        var pkgbuildPath = Path.Combine(cachePath, "PKGBUILD");
+
+        if (!File.Exists(pkgbuildPath))
+        {
+            var success = await DownloadPackage(packageName);
+            if (!success)
+                return null;
+        }
+
+        var pkgbuildContent = await File.ReadAllTextAsync(pkgbuildPath);
+        var pkgbuildInfo = PkgbuildParser.ParseContent(pkgbuildContent);
+        var entries = VcsSourceParser.ParseSources(pkgbuildInfo.Source);
+        return entries.Count > 0 ? entries : null;
+    }
+
+    /// <summary>
+    /// Runs git ls-remote to get the current commit SHA for a given URL and branch.
+    /// Uses a 15-second timeout matching yay's behavior.
+    /// </summary>
+    private static async Task<string?> GetRemoteCommitSha(string url, string branch, int timeoutSeconds = 15)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"ls-remote {url} {branch}",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+
+            var output = await process.StandardOutput.ReadToEndAsync(cts.Token);
+            await process.WaitForExitAsync(cts.Token);
+
+            if (process.ExitCode != 0)
+                return null;
+
+            // Output format: "<sha>\t<ref>\n"
+            var line = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (line == null)
+                return null;
+
+            var sha = line.Split('\t', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            return string.IsNullOrWhiteSpace(sha) ? null : sha.Trim();
+        }
+        catch (OperationCanceledException)
+        {
+            await Console.Error.WriteLineAsync($"Timeout checking git remote: {url}");
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Updates the VCS info store after a successful package build/install.
+    /// Parses sources and captures current remote commit SHAs.
+    /// </summary>
+    private async Task UpdateVcsStoreForPackage(string packageName, string pkgbuildPath)
+    {
+        if (!IsVcsPackage(packageName))
+            return;
+
+        try
+        {
+            var pkgbuildContent = await File.ReadAllTextAsync(pkgbuildPath);
+            var pkgbuildInfo = PkgbuildParser.ParseContent(pkgbuildContent);
+            var entries = VcsSourceParser.ParseSources(pkgbuildInfo.Source);
+
+            if (entries.Count == 0)
+                return;
+
+            foreach (var entry in entries)
+            {
+                var sha = await GetRemoteCommitSha(entry.Url, entry.Branch);
+                if (sha != null)
+                    entry.CommitSha = sha;
+            }
+
+            _vcsInfoStore.SetEntries(packageName, entries);
+            await _vcsInfoStore.Save();
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"Warning: Failed to update VCS store for {packageName}: {ex.Message}");
+        }
+    }
+
+    private static readonly string[] VcsSuffixes = ["-git"];
+
+    private static bool IsVcsPackage(string packageName)
+    {
+        return VcsSuffixes.Any(suffix => packageName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/PackageManager/Aur/AurPackageManager.cs
+++ b/PackageManager/Aur/AurPackageManager.cs
@@ -1659,7 +1659,7 @@ public class AurPackageManager(string? configPath = null)
 
     /// <summary>
     /// Checks if a VCS package needs an update by comparing stored commit SHAs
-    /// with remote SHAs via git ls-remote (matching yay/paru behavior).
+    /// with remote SHAs via git ls-remote.
     /// </summary>
     private async Task<bool> CheckVcsPackageNeedsUpdate(string packageName)
     {
@@ -1724,7 +1724,6 @@ public class AurPackageManager(string? configPath = null)
 
     /// <summary>
     /// Runs git ls-remote to get the current commit SHA for a given URL and branch.
-    /// Uses a 15-second timeout matching yay's behavior.
     /// </summary>
     private static async Task<string?> GetRemoteCommitSha(string url, string branch, int timeoutSeconds = 15)
     {

--- a/PackageManager/Aur/IAurPackageManager.cs
+++ b/PackageManager/Aur/IAurPackageManager.cs
@@ -15,7 +15,7 @@ public interface IAurPackageManager : IDisposable
     Task<List<AurPackageDto>> GetInstalledPackages();
     Task<List<AurPackageDto>> SearchPackages(string query);
 
-    Task<List<AurUpdateDto>> GetPackagesNeedingUpdate();
+    Task<List<AurUpdateDto>> GetPackagesNeedingUpdate(bool checkDevel = true);
 
     Task UpdatePackages(List<string> packageNames);
 

--- a/PackageManager/Aur/Models/AurJsonContext.cs
+++ b/PackageManager/Aur/Models/AurJsonContext.cs
@@ -8,6 +8,7 @@ namespace PackageManager.Aur.Models;
 [JsonSerializable(typeof(AurUpdateDto))]
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(List<AurPackageDto>))]
+[JsonSerializable(typeof(Dictionary<string, List<VcsSourceEntry>>))]
 public partial class AurJsonContext : JsonSerializerContext
 {
 }

--- a/PackageManager/Aur/Models/VcsSourceEntry.cs
+++ b/PackageManager/Aur/Models/VcsSourceEntry.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace PackageManager.Aur.Models;
+
+public class VcsSourceEntry
+{
+    public string Url { get; set; } = string.Empty;
+    public string Branch { get; set; } = string.Empty;
+    public List<string> Protocols { get; set; } = [];
+    public string CommitSha { get; set; } = string.Empty;
+}

--- a/PackageManager/Aur/VcsInfoStore.cs
+++ b/PackageManager/Aur/VcsInfoStore.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using PackageManager.Aur.Models;
+
+namespace PackageManager.Aur;
+
+public class VcsInfoStore
+{
+    private readonly string _storePath;
+    private Dictionary<string, List<VcsSourceEntry>> _entries = new();
+
+    public VcsInfoStore()
+    {
+        var user = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
+        var home = $"/home/{user}";
+        _storePath = Path.Combine(home, ".local", "share", "Shelly", "vcs.json");
+    }
+
+    public async Task Load()
+    {
+        if (!File.Exists(_storePath))
+        {
+            _entries = new Dictionary<string, List<VcsSourceEntry>>();
+            return;
+        }
+
+        await using var stream = File.OpenRead(_storePath);
+        _entries = await JsonSerializer.DeserializeAsync(
+            stream,
+            AurJsonContext.Default.DictionaryStringListVcsSourceEntry
+        ) ?? new Dictionary<string, List<VcsSourceEntry>>();
+    }
+
+    public async Task Save()
+    {
+        var dir = Path.GetDirectoryName(_storePath)!;
+        Directory.CreateDirectory(dir);
+
+        await using var stream = File.Create(_storePath);
+        await JsonSerializer.SerializeAsync(
+            stream,
+            _entries,
+            AurJsonContext.Default.DictionaryStringListVcsSourceEntry
+        );
+    }
+
+    public List<VcsSourceEntry>? GetEntries(string packageName)
+        => _entries.TryGetValue(packageName, out var entries) ? entries : null;
+
+    public void SetEntries(string packageName, List<VcsSourceEntry> entries)
+        => _entries[packageName] = entries;
+
+    public void RemovePackage(string packageName)
+        => _entries.Remove(packageName);
+
+    public void Clean(IEnumerable<string> installedPackageNames)
+    {
+        var installed = new HashSet<string>(installedPackageNames);
+        var orphaned = _entries.Keys.Where(k => !installed.Contains(k)).ToList();
+        foreach (var key in orphaned)
+            _entries.Remove(key);
+    }
+}

--- a/PackageManager/Aur/VcsSourceParser.cs
+++ b/PackageManager/Aur/VcsSourceParser.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PackageManager.Aur.Models;
+
+namespace PackageManager.Aur;
+
+/// <summary>
+/// Parses PKGBUILD/SRCINFO source entries for VCS (git) sources,
+/// following the same logic as yay's parseSource function.
+/// </summary>
+public static class VcsSourceParser
+{
+    /// <summary>
+    /// Parses a single PKGBUILD source entry and returns a <see cref="VcsSourceEntry"/> if it is
+    /// a trackable git source (i.e., not pinned with #commit= or #tag=). Returns null otherwise.
+    /// </summary>
+    public static VcsSourceEntry? ParseSource(string sourceEntry)
+    {
+        if (string.IsNullOrWhiteSpace(sourceEntry))
+            return null;
+
+        var entry = sourceEntry.Trim();
+
+        // Strip "name::" prefix (e.g., "pkgname::git+https://...")
+        var colonColonIndex = entry.IndexOf("::", StringComparison.Ordinal);
+        if (colonColonIndex >= 0)
+        {
+            entry = entry[(colonColonIndex + 2)..];
+        }
+
+        // Parse protocols (e.g., "git+https://..." -> protocols=["git","https"], url="https://...")
+        var protocols = new List<string>();
+        var url = entry;
+
+        // Extract protocols before "://"
+        var schemeEnd = entry.IndexOf("://", StringComparison.Ordinal);
+        if (schemeEnd < 0)
+            return null;
+
+        var schemePart = entry[..schemeEnd];
+        url = entry; // keep full URL for git operations
+
+        // Split protocols by "+"
+        protocols.AddRange(schemePart.Split('+', StringSplitOptions.RemoveEmptyEntries));
+
+        // Only process git sources
+        if (!protocols.Contains("git", StringComparer.OrdinalIgnoreCase))
+            return null;
+
+        // Remove the "git+" prefix from the URL for actual git operations
+        // e.g., "git+https://github.com/foo/bar.git" -> "https://github.com/foo/bar.git"
+        if (url.StartsWith("git+", StringComparison.OrdinalIgnoreCase))
+        {
+            url = url[4..];
+        }
+
+        // Parse fragment (#branch=, #commit=, #tag=)
+        string branch = "HEAD";
+        var fragmentIndex = url.IndexOf('#');
+        if (fragmentIndex >= 0)
+        {
+            var fragment = url[(fragmentIndex + 1)..];
+            url = url[..fragmentIndex];
+
+            // Skip sources pinned to a specific commit or tag — these are not VCS-tracking
+            if (fragment.StartsWith("commit=", StringComparison.OrdinalIgnoreCase) ||
+                fragment.StartsWith("tag=", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (fragment.StartsWith("branch=", StringComparison.OrdinalIgnoreCase))
+            {
+                branch = fragment.Split('=', 2)[1];
+            }
+        }
+
+        // Strip query parameters (e.g., "?signed")
+        var queryIndex = url.IndexOf('?');
+        if (queryIndex >= 0)
+        {
+            url = url[..queryIndex];
+        }
+
+        return new VcsSourceEntry
+        {
+            Url = url,
+            Branch = branch,
+            Protocols = protocols.Where(p => !p.Equals("git", StringComparison.OrdinalIgnoreCase)).ToList(),
+            CommitSha = string.Empty
+        };
+    }
+
+    /// <summary>
+    /// Parses all source entries from a PKGBUILD and returns the trackable git sources.
+    /// </summary>
+    public static List<VcsSourceEntry> ParseSources(IEnumerable<string> sources)
+    {
+        var results = new List<VcsSourceEntry>();
+        foreach (var source in sources)
+        {
+            var parsed = ParseSource(source);
+            if (parsed != null)
+                results.Add(parsed);
+        }
+        return results;
+    }
+}

--- a/PackageManager/Aur/VcsSourceParser.cs
+++ b/PackageManager/Aur/VcsSourceParser.cs
@@ -5,16 +5,8 @@ using PackageManager.Aur.Models;
 
 namespace PackageManager.Aur;
 
-/// <summary>
-/// Parses PKGBUILD/SRCINFO source entries for VCS (git) sources,
-/// following the same logic as yay's parseSource function.
-/// </summary>
 public static class VcsSourceParser
 {
-    /// <summary>
-    /// Parses a single PKGBUILD source entry and returns a <see cref="VcsSourceEntry"/> if it is
-    /// a trackable git source (i.e., not pinned with #commit= or #tag=). Returns null otherwise.
-    /// </summary>
     public static VcsSourceEntry? ParseSource(string sourceEntry)
     {
         if (string.IsNullOrWhiteSpace(sourceEntry))
@@ -22,40 +14,32 @@ public static class VcsSourceParser
 
         var entry = sourceEntry.Trim();
 
-        // Strip "name::" prefix (e.g., "pkgname::git+https://...")
         var colonColonIndex = entry.IndexOf("::", StringComparison.Ordinal);
         if (colonColonIndex >= 0)
         {
             entry = entry[(colonColonIndex + 2)..];
         }
 
-        // Parse protocols (e.g., "git+https://..." -> protocols=["git","https"], url="https://...")
         var protocols = new List<string>();
         var url = entry;
 
-        // Extract protocols before "://"
         var schemeEnd = entry.IndexOf("://", StringComparison.Ordinal);
         if (schemeEnd < 0)
             return null;
 
         var schemePart = entry[..schemeEnd];
-        url = entry; // keep full URL for git operations
+        url = entry;
 
-        // Split protocols by "+"
         protocols.AddRange(schemePart.Split('+', StringSplitOptions.RemoveEmptyEntries));
 
-        // Only process git sources
         if (!protocols.Contains("git", StringComparer.OrdinalIgnoreCase))
             return null;
 
-        // Remove the "git+" prefix from the URL for actual git operations
-        // e.g., "git+https://github.com/foo/bar.git" -> "https://github.com/foo/bar.git"
         if (url.StartsWith("git+", StringComparison.OrdinalIgnoreCase))
         {
             url = url[4..];
         }
 
-        // Parse fragment (#branch=, #commit=, #tag=)
         string branch = "HEAD";
         var fragmentIndex = url.IndexOf('#');
         if (fragmentIndex >= 0)
@@ -63,7 +47,6 @@ public static class VcsSourceParser
             var fragment = url[(fragmentIndex + 1)..];
             url = url[..fragmentIndex];
 
-            // Skip sources pinned to a specific commit or tag — these are not VCS-tracking
             if (fragment.StartsWith("commit=", StringComparison.OrdinalIgnoreCase) ||
                 fragment.StartsWith("tag=", StringComparison.OrdinalIgnoreCase))
             {
@@ -76,7 +59,6 @@ public static class VcsSourceParser
             }
         }
 
-        // Strip query parameters (e.g., "?signed")
         var queryIndex = url.IndexOf('?');
         if (queryIndex >= 0)
         {
@@ -92,9 +74,6 @@ public static class VcsSourceParser
         };
     }
 
-    /// <summary>
-    /// Parses all source entries from a PKGBUILD and returns the trackable git sources.
-    /// </summary>
     public static List<VcsSourceEntry> ParseSources(IEnumerable<string> sources)
     {
         var results = new List<VcsSourceEntry>();


### PR DESCRIPTION
- Introduce `VcsSourceParser` for parsing VCS (e.g., git) PKGBUILD sources.
- Add `VcsSourceEntry` model to manage VCS package details, including URL, branch, and commit SHA.
- Implement `VcsInfoStore` to persist and compare VCS source state across updates.
- Update `AurPackageManager` to track and determine updates for VCS packages using git commit SHAs.
- Enhance AUR update logic to include VCS packages, ensuring up-to-date installs.
- Add comprehensive tests for VCS source parsing and update handling logic.