### PR TITLE
Fix `RestartManager` to return empty list temporarily for services needing restart

### DIFF
--- a/PackageManager/Utilities/RestartManager.cs
+++ b/PackageManager/Utilities/RestartManager.cs
@@ -69,8 +69,8 @@ public static class RestartManager
                 continue;
             }
         }
-
-        return (needsReboot, servicesNeedingRestart.ToList());
+        // Use  servicesNeedingRestart.ToList() after fixing above problems
+        return (needsReboot,[]);
     }
 
     public static async Task<List<(string service, string error)>> RestartServicesAsync(List<string> services)


### PR DESCRIPTION
stops sending services to the shadow realm, while this part of the feature is reworked.