### PR TITLE
Improving memory usage of session logger

### DIFF
--- a/Shelly-CLI/Writers/ShellyFileLogger.cs
+++ b/Shelly-CLI/Writers/ShellyFileLogger.cs
@@ -27,6 +27,9 @@ public class ShellyFileLogger : TextWriter
     ];
     private static readonly Regex BoxBorder = new(@"^[\s┌┐└┘─│╔╗╚╝═║]+$", RegexOptions.Compiled);
     private static readonly Regex BoxContent = new(@"│([^│]*)│?", RegexOptions.Compiled);
+    private static readonly Regex PrefixNoise = new(@"\[Shelly\](?:\[(?:DEBUG|DEBUG_LOG|ALPM.*?|Shelly)\])*", RegexOptions.Compiled);
+    private static readonly Regex DuplicateTag = new(@"\[(ERR|OUT)\]\s*\[Shelly\]", RegexOptions.Compiled);
+
     
     private const string LogPath = "/var/log/shelly.log";
     private const string RotatedLogPath = "/var/log/shelly.log.1";
@@ -84,7 +87,12 @@ public class ShellyFileLogger : TextWriter
             _tuiFrameBuffer.Add(clean);
             return;
         }
+
+        clean = DuplicateTag.Replace(clean, "[$1]");
+        clean = PrefixNoise.Replace(clean, "");
+
         if (NoisePatterns.Any(p => p.IsMatch(clean))) return;
+
         WriteToLog(clean);
     }
     

--- a/Shelly.Gtk/UiModels/OperationLogEntry.cs
+++ b/Shelly.Gtk/UiModels/OperationLogEntry.cs
@@ -14,6 +14,5 @@ public class OperationLogEntry
     public int StartLine { get; set; }
     public int EndLine { get; set; }
     
-    public string SessionId => Timestamp.ToString("yyyyMMdd_HHmmss");
 
 }

--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -26,10 +26,12 @@ public class HomeWindow(
     MetaSearch metaSearch) : IShellyWindow
 {
     private Box _box = null!;
+    private Box _logBox = null!;
     private readonly CancellationTokenSource _cts = new();
     private ListBox? _updatesListBox;
     private List<RssModel> _archNewsItems = [];
     private List<RssModel> _newArchNewsItems = [];
+    private List<OperationLogEntry>? _logEntries = [];
     private Label? _totalAurLabel;
     private Label? _percentAurLabel;
     private Label? _totalPackageLabel;
@@ -40,6 +42,7 @@ public class HomeWindow(
     private Button _archNewsButton = null!;
     private Widget? _activeSessionLogOverlay;
     private Overlay _overlay = null!;
+    private GenericDialogEventArgs _args;
     private uint _updateTimerId;
     private const int MaxRawLineBytes = 50 * 1024 * 1024; // 50 MB
     private GObject.SignalHandler<ListBox, ListBox.RowActivatedSignalArgs>? _logRowActivatedHandler;
@@ -857,7 +860,7 @@ public class HomeWindow(
     {
         try
         {
-            var entries = await operationLogService.GetRecentOperationsAsync(8);
+            _logEntries  = await operationLogService.GetRecentOperationsAsync(8);
             ct.ThrowIfCancellationRequested();
 
             GLib.Functions.IdleAdd(0, () =>
@@ -867,7 +870,7 @@ public class HomeWindow(
                 while (_operationLogListBox.GetFirstChild() is { } child)
                     _operationLogListBox.Remove(child);
 
-                if (entries.Count == 0)
+                if (_logEntries.Count == 0)
                 {
                     var placeholder = Label.New("No recent activity");
                     placeholder.AddCssClass("dim-label");
@@ -880,7 +883,7 @@ public class HomeWindow(
                     return false;
                 }
 
-                foreach (var entry in entries)
+                foreach (var entry in _logEntries)
                 {
                     var row = new ListBoxRow();
                     row.SetActivatable(true);
@@ -926,7 +929,7 @@ public class HomeWindow(
                 if (_logRowActivatedHandler is not null)
                     _operationLogListBox.OnRowActivated -= _logRowActivatedHandler;
 
-                _logRowActivatedHandler = (sender, args) => OnLogRowActivated(args.Row, entries);
+                _logRowActivatedHandler = (sender, args) => OnLogRowActivated(args.Row, _logEntries);
                 _operationLogListBox.OnRowActivated += _logRowActivatedHandler;
                 
                 return false;
@@ -938,7 +941,7 @@ public class HomeWindow(
         }
     }
     
-    private async void OnLogRowActivated(ListBoxRow row, List<OperationLogEntry> entries)
+    private async Task OnLogRowActivated(ListBoxRow row, List<OperationLogEntry> entries) 
     {
         var index = row.GetIndex();
         if (index < 0 || index >= entries.Count) return;
@@ -963,18 +966,18 @@ public class HomeWindow(
             return;
         }
 
-        var container = new Box();
-        container.SetOrientation(Orientation.Vertical);
-        container.SetSpacing(10);
-        container.SetMarginTop(10);
-        container.SetMarginBottom(10);
-        container.SetMarginStart(10);
-        container.SetMarginEnd(10);
+        _logBox = new Box();
+        _logBox.SetOrientation(Orientation.Vertical);
+        _logBox.SetSpacing(10);
+        _logBox.SetMarginTop(10);
+        _logBox.SetMarginBottom(10);
+        _logBox.SetMarginStart(10);
+        _logBox.SetMarginEnd(10);
 
         var titleLabel = Label.New("Session Log");
         titleLabel.AddCssClass("title-1");
         titleLabel.Xalign = 0;
-        container.Append(titleLabel);
+        _logBox.Append(titleLabel);
 
         var listBox = new ListBox();
         listBox.SetSelectionMode(SelectionMode.Multiple);
@@ -984,7 +987,7 @@ public class HomeWindow(
         scrolledWindow.HscrollbarPolicy = PolicyType.Automatic;
         scrolledWindow.SetChild(listBox);
 
-        container.Append(scrolledWindow);
+        _logBox.Append(scrolledWindow);
         
         int batchSize = 200;
         int currentIndex = 0;
@@ -1038,12 +1041,13 @@ public class HomeWindow(
             );
         };
 
-        container.Append(copyButton);
+        _logBox.Append(copyButton);
 
-        var args = new GenericDialogEventArgs(container);
-        GenericOverlay.ShowGenericOverlay(_overlay, container, args, 700, 500);
+        _args = new GenericDialogEventArgs(_logBox);
+        GenericOverlay.ShowGenericOverlay(_overlay, _logBox, _args, 700, 500);
 
-        _activeSessionLogOverlay = container;
+        _activeSessionLogOverlay = _logBox;
+        
     }    
     private static string GetIconForCommand(string command)
     {
@@ -1080,5 +1084,10 @@ public class HomeWindow(
 
         _cts.Cancel();
         _cts.Dispose();
+        _logEntries?.Clear();
+        _logEntries = null;
+        _logBox.Dispose();
+        _args = null!;
+
     }
 }

--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -951,15 +951,7 @@ public class HomeWindow(
         if (index < 0 || index >= entries.Count) return;
 
         var entry = entries[index];
-
-        if (_activeSessionLogOverlay is { } oldBox && oldBox.GetParent() == _overlay)
-        {
-            try { _overlay.RemoveOverlay(oldBox); } catch { }
-            oldBox.Unparent();
-            oldBox.Dispose();
-            _activeSessionLogOverlay = null;
-        }
-
+        
         var lines = await operationLogService.GetSessionExcerptAsync(entry, MaxRawLineBytes);
 
         if (lines.Count == 0)

--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -33,6 +33,7 @@ public class HomeWindow(
     private List<RssModel> _archNewsItems = [];
     private List<RssModel> _newArchNewsItems = [];
     private List<OperationLogEntry>? _logEntries = [];
+    private List<string> _logLines = [];
     private Label? _totalAurLabel;
     private Label? _percentAurLabel;
     private Label? _totalPackageLabel;
@@ -952,9 +953,9 @@ public class HomeWindow(
 
         var entry = entries[index];
         
-        var lines = await operationLogService.GetSessionExcerptAsync(entry, MaxRawLineBytes);
+        _logLines = await operationLogService.GetSessionExcerptAsync(entry, MaxRawLineBytes);
 
-        if (lines.Count == 0)
+        if (_logLines.Count == 0)
         {
             genericQuestionService.RaiseToastMessage(
                 new ToastMessageEventArgs("Session log is too large to display")
@@ -966,7 +967,7 @@ public class HomeWindow(
         {
             try
             {
-                var fullLogText = string.Join("\n", lines);
+                var fullLogText = string.Join("\n", _logLines);
 
                 _logBox = new Box();
                 _logBox.SetOrientation(Orientation.Vertical);
@@ -1019,12 +1020,12 @@ public class HomeWindow(
             }
             catch (Exception e)
             {
-                // Here to not throw anything in case something goes wrong.
             }
 
             return false;
         });
     }
+    
     
     private static string GetIconForCommand(string command)
     {
@@ -1064,6 +1065,8 @@ public class HomeWindow(
         _cts.Dispose();
         _logEntries?.Clear();
         _logEntries = null;
+        _logLines.Clear();
+        _logLines = null;
         _args = null!;
 
     }

--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -26,7 +26,7 @@ public class HomeWindow(
     MetaSearch metaSearch) : IShellyWindow
 {
     private Box _box = null!;
-    private Box _logBox = null!;
+    private Box? _logBox;
     private readonly CancellationTokenSource _cts = new();
     private ListBox? _updatesListBox;
     private List<RssModel> _archNewsItems = [];
@@ -989,7 +989,7 @@ public class HomeWindow(
 
         _logBox.Append(scrolledWindow);
         
-        int batchSize = 200;
+        int batchSize = 100;
         int currentIndex = 0;
 
         void AppendNextBatch()
@@ -1082,11 +1082,11 @@ public class HomeWindow(
             _updateTimerId = 0;
         }
 
+        _logBox?.Dispose();
         _cts.Cancel();
         _cts.Dispose();
         _logEntries?.Clear();
         _logEntries = null;
-        _logBox.Dispose();
         _args = null!;
 
     }

--- a/Shelly.Gtk/Windows/HomeWindow.cs
+++ b/Shelly.Gtk/Windows/HomeWindow.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Tracing;
 using System.Text;
 using Gtk;
 using Microsoft.VisualBasic.FileIO;
@@ -46,6 +47,9 @@ public class HomeWindow(
     private uint _updateTimerId;
     private const int MaxRawLineBytes = 50 * 1024 * 1024; // 50 MB
     private GObject.SignalHandler<ListBox, ListBox.RowActivatedSignalArgs>? _logRowActivatedHandler;
+    GObject.SignalHandler<Adjustment>? _vadjHandler;
+    GObject.SignalHandler<Adjustment>? _clickHandler;
+
 
 
     public Widget CreateWindow()
@@ -966,89 +970,70 @@ public class HomeWindow(
             return;
         }
 
-        _logBox = new Box();
-        _logBox.SetOrientation(Orientation.Vertical);
-        _logBox.SetSpacing(10);
-        _logBox.SetMarginTop(10);
-        _logBox.SetMarginBottom(10);
-        _logBox.SetMarginStart(10);
-        _logBox.SetMarginEnd(10);
-
-        var titleLabel = Label.New("Session Log");
-        titleLabel.AddCssClass("title-1");
-        titleLabel.Xalign = 0;
-        _logBox.Append(titleLabel);
-
-        var listBox = new ListBox();
-        listBox.SetSelectionMode(SelectionMode.Multiple);
-
-        var scrolledWindow = new ScrolledWindow();
-        scrolledWindow.SetVexpand(true);
-        scrolledWindow.HscrollbarPolicy = PolicyType.Automatic;
-        scrolledWindow.SetChild(listBox);
-
-        _logBox.Append(scrolledWindow);
-        
-        int batchSize = 100;
-        int currentIndex = 0;
-
-        void AppendNextBatch()
+        GLib.Functions.IdleAdd(0, () =>
         {
-            int end = Math.Min(currentIndex + batchSize, lines.Count);
-
-            for (int i = currentIndex; i < end; i++)
+            try
             {
-                var rowItem = new ListBoxRow();
+                var fullLogText = string.Join("\n", lines);
 
-                var label = Label.New(lines[i]);
-                label.Xalign = 0;
-                label.Wrap = true;
-                label.Selectable = true;
+                _logBox = new Box();
+                _logBox.SetOrientation(Orientation.Vertical);
+                _logBox.SetSpacing(10);
+                _logBox.SetMarginTop(10);
+                _logBox.SetMarginBottom(10);
+                _logBox.SetMarginStart(10);
+                _logBox.SetMarginEnd(10);
 
-                rowItem.SetChild(label);
-                listBox.Append(rowItem);
-            }
+                var titleLabel = Label.New("Session Log");
+                titleLabel.AddCssClass("title-1");
+                titleLabel.Xalign = 0;
+                _logBox.Append(titleLabel);
 
-            currentIndex = end;
-        }
+                var textView = new TextView();
+                textView.Editable = false;
+                textView.WrapMode = WrapMode.WordChar;
 
-        AppendNextBatch();
+                var buffer = textView.Buffer;
+                
+                buffer?.SetText(fullLogText, -1);
 
-        var vadj = scrolledWindow.Vadjustment;
-        vadj.OnValueChanged += (_, _) =>
-        {
-            if (vadj.Value + vadj.PageSize >= vadj.Upper - 50)
-            {
-                if (currentIndex < lines.Count)
+                var scrolledWindow = new ScrolledWindow();
+                scrolledWindow.SetVexpand(true);
+                scrolledWindow.HscrollbarPolicy = PolicyType.Automatic;
+                scrolledWindow.SetChild(textView);
+                _logBox.Append(scrolledWindow);
+
+                var copyButton = Button.NewWithLabel("Copy Log");
+                copyButton.Halign = Align.Start;
+
+                copyButton.OnClicked += (_, _) =>
                 {
-                    AppendNextBatch();
-                }
+                    var text = fullLogText; 
+
+                    var clipboard = Gdk.Display.GetDefault().GetClipboard();
+                    clipboard.SetText(text);
+
+                    genericQuestionService.RaiseToastMessage(
+                        new ToastMessageEventArgs("Log copied to clipboard")
+                    );
+                };
+
+                _logBox.Append(copyButton);
+
+                _args = new GenericDialogEventArgs(_logBox);
+                GenericOverlay.ShowGenericOverlay(_overlay, _logBox, _args, 700, 500);
+
+                _activeSessionLogOverlay = _logBox;
             }
-        };
-        
-        var copyButton = Button.NewWithLabel("Copy Log");
-        copyButton.Halign = Align.Start;
+            catch (Exception e)
+            {
+                // Here to not throw anything in case something goes wrong.
+            }
 
-        copyButton.OnClicked += (_, _) =>
-        {
-            var text = string.Join("\n", lines);
-
-            var clipboard = Gdk.Display.GetDefault().GetClipboard();
-            clipboard.SetText(text);
-
-            genericQuestionService.RaiseToastMessage(
-                new ToastMessageEventArgs("Log copied to clipboard")
-            );
-        };
-
-        _logBox.Append(copyButton);
-
-        _args = new GenericDialogEventArgs(_logBox);
-        GenericOverlay.ShowGenericOverlay(_overlay, _logBox, _args, 700, 500);
-
-        _activeSessionLogOverlay = _logBox;
-        
-    }    
+            return false;
+        });
+    }
+    
     private static string GetIconForCommand(string command)
     {
         if (command.Contains("sync", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This PR improves memory usage  when opening and closing Session Log windows. It also adds a small refactor to the CLI logging service to prevent too many repeated progress lines from being generated.