### PR TITLE
Add animated and configurable progress bar support across CLI commands

### DIFF
--- a/Shelly-CLI/Commands/Aur/AurRemoveCommand.cs
+++ b/Shelly-CLI/Commands/Aur/AurRemoveCommand.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using PackageManager.Alpm;
 using PackageManager.Aur;
+using Shelly_CLI.ConsoleLayouts;
 using Shelly_CLI.Utility;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -98,7 +99,7 @@ public class AurRemoveCommand : AsyncCommand<AurRemovePackageSettings>
                         {
                             var name = args.PackageName ?? "unknown";
                             var pct = args.Percent ?? 0;
-                            var bar = new string('█', pct / 5) + new string('░', 20 - pct / 5);
+                            var bar = ProgressBarRenderer.RenderStatic(pct, 20);
                             var actionType = args.ProgressType;
 
                             if (!rowIndex.TryGetValue(name, out var idx))

--- a/Shelly-CLI/Commands/Standard/SyncCommand.cs
+++ b/Shelly-CLI/Commands/Standard/SyncCommand.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using PackageManager.Alpm;
+using Shelly_CLI.ConsoleLayouts;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -36,7 +37,7 @@ public class SyncCommand : Command<SyncSettings>
                     {
                         var name = args.PackageName ?? "unknown";
                         var pct = args.Percent ?? 0;
-                        var bar = new string('█', pct / 5) + new string('░', 20 - pct / 5);
+                        var bar = ProgressBarRenderer.RenderStatic(pct, 20);
                         var actionType = args.ProgressType;
 
                         if (!rowIndex.TryGetValue(name, out var idx))

--- a/Shelly-CLI/Commands/Standard/UpdateCommand.cs
+++ b/Shelly-CLI/Commands/Standard/UpdateCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using PackageManager.Alpm;
+using Shelly_CLI.ConsoleLayouts;
 using Shelly_CLI.Utility;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -74,7 +75,7 @@ public class UpdateCommand : Command<PackageSettings>
                     {
                         var name = args.PackageName ?? "unknown";
                         var pct = args.Percent ?? 0;
-                        var bar = new string('█', pct / 5) + new string('░', 20 - pct / 5);
+                        var bar = ProgressBarRenderer.RenderStatic(pct, 20);
                         var actionType = args.ProgressType;
 
                         if (!rowIndex.TryGetValue(name, out var idx))

--- a/Shelly-CLI/Configuration/ConfigManager.cs
+++ b/Shelly-CLI/Configuration/ConfigManager.cs
@@ -130,7 +130,34 @@ public static class ConfigManager
             }
             else
             {
-                convertedValue = value;
+                if (property.Name == nameof(ShellyConfig.ProgressBarStyle))
+                {
+                    if (!Enum.TryParse<ProgressBarStyleKind>(value, true, out var parsed))
+                    {
+                        return false;
+                    }
+                    convertedValue = parsed.ToString();
+                }
+                else if (property.Name == nameof(ShellyConfig.FileSizeDisplay))
+                {
+                    if (!Enum.TryParse<SizeDisplay>(value, true, out var parsed))
+                    {
+                        return false;
+                    }
+                    convertedValue = parsed.ToString();
+                }
+                else if (property.Name == nameof(ShellyConfig.DefaultExecution))
+                {
+                    if (!Enum.TryParse<DefaultCommand>(value, true, out var parsed))
+                    {
+                        return false;
+                    }
+                    convertedValue = parsed.ToString();
+                }
+                else
+                {
+                    convertedValue = value;
+                }
             }
         }
         catch

--- a/Shelly-CLI/Configuration/ProgressBarStyleKind.cs
+++ b/Shelly-CLI/Configuration/ProgressBarStyleKind.cs
@@ -1,0 +1,7 @@
+namespace Shelly_CLI.Configuration;
+
+public enum ProgressBarStyleKind
+{
+    Blocks,
+    Pacman
+}

--- a/Shelly-CLI/Configuration/ShellyConfig.cs
+++ b/Shelly-CLI/Configuration/ShellyConfig.cs
@@ -33,4 +33,8 @@ public class ShellyConfig
     public bool ShellyIconsEnabled { get; set; } = true;
     public bool AppImageEnabled { get; set; } = false;
     public bool NewInstallInitSettings { get; set; } = false;
+
+    public string ProgressBarStyle { get; set; } = nameof(ProgressBarStyleKind.Blocks);
+    public int ProgressBarFps { get; set; } = 7;
+    public int ProgressBarWidth { get; set; } = 24;
 }

--- a/Shelly-CLI/ConsoleLayouts/AurSplitOutput.cs
+++ b/Shelly-CLI/ConsoleLayouts/AurSplitOutput.cs
@@ -1,5 +1,6 @@
 using PackageManager.Alpm;
 using PackageManager.Aur;
+using Shelly_CLI.Configuration;
 using Shelly_CLI.Utility;
 using Spectre.Console;
 
@@ -7,11 +8,26 @@ namespace Shelly_CLI.ConsoleLayouts;
 
 public static class AurSplitOutput
 {
+    private sealed class BarState
+    {
+        public string Name = "";
+        public ulong Current;
+        public ulong HowMany;
+        public int Pct;
+        public string ActionType = "";
+        public bool Completed;
+    }
+
     public static async Task<bool> Output(AurPackageManager manager, Func<AurPackageManager, Task> operation,
         bool noConfirm = false,
         int consoleRatio = 3,
         int progressRatio = 2)
     {
+        var cfg = ConfigManager.ReadConfig();
+        var style = ProgressBarRenderer.ParseStyle(cfg.ProgressBarStyle);
+        var fps = Math.Clamp(cfg.ProgressBarFps, 1, 30);
+        var barWidth = cfg.ProgressBarWidth;
+
         var consoleLines = new List<string>();
         var progressLines = new List<string>();
         var maxVisibleLines = Console.WindowHeight - 4;
@@ -66,26 +82,47 @@ public static class AurSplitOutput
             }
         };
 
+        var rows = new Dictionary<string, BarState>(StringComparer.Ordinal);
+        var order = new List<string>();
+
+        string RenderLine(BarState r, int frame)
+        {
+            var bar = ProgressBarRenderer.Render(r.Pct, frame, style, barWidth);
+            return $"({r.Current}/{r.HowMany}) {r.ActionType} " +
+                   $"[bold]{r.Name.EscapeMarkup()}[/] {bar} {r.Pct,3}%";
+        }
+
+        void RebuildProgressLines(int frame)
+        {
+            progressLines.Clear();
+            foreach (var key in order)
+            {
+                progressLines.Add(RenderLine(rows[key], frame));
+            }
+        }
+
         manager.Progress += (sender, e) =>
         {
             var name = e.PackageName ?? "unknown";
             var pct = e.Percent ?? 0;
-            var bar = new string('█', pct / 5) + new string('░', 20 - pct / 5);
-            var actionType = e.ProgressType;
-
-            var line =
-                $"({e.Current}/{e.HowMany}) {actionType} [bold]{name.EscapeMarkup()}[/] [green]{bar}[/] {pct,3}%";
+            var actionType = e.ProgressType.ToString();
 
             lock (renderLock)
             {
-                if (progressLines.Count > 0 && progressLines[^1].Contains(name.EscapeMarkup()))
+                if (!rows.TryGetValue(name, out var r))
                 {
-                    progressLines[^1] = line;
+                    r = new BarState { Name = name };
+                    rows[name] = r;
+                    order.Add(name);
                 }
-                else
-                {
-                    progressLines.Add(line);
-                }
+
+                r.Current = e.Current ?? 0;
+                r.HowMany = e.HowMany ?? 0;
+                r.Pct = pct;
+                r.ActionType = actionType;
+                if (pct >= 100) r.Completed = true;
+
+                RebuildProgressLines(frame: 0);
 
                 var visible = progressLines.Skip(Math.Max(0, progressLines.Count - maxVisibleLines)).ToList();
                 layout["Progress"].Update(
@@ -246,9 +283,7 @@ public static class AurSplitOutput
                 if (e.Percent.HasValue)
                 {
                     var prefix = $"[bold]{e.PackageName.EscapeMarkup()}[/] ";
-                    var barLength = 20;
-                    var filled = (int)(barLength * e.Percent.Value / 100.0);
-                    var bar = new string('█', filled) + new string('░', barLength - filled);
+                    var bar = ProgressBarRenderer.RenderStatic(e.Percent.Value, 20);
                     var line =
                         $"{prefix}[yellow]{bar} {e.Percent.Value}%[/] {(e.ProgressMessage ?? "").EscapeMarkup()}";
 
@@ -356,7 +391,44 @@ public static class AurSplitOutput
         await AnsiConsole.Live(layout).StartAsync(async ctx =>
         {
             liveCtx = ctx;
-            await operation(manager);
+
+            if (!ProgressBarRenderer.ShouldAnimate(style))
+            {
+                await operation(manager);
+                return;
+            }
+
+            using var cts = new CancellationTokenSource();
+            var delay = TimeSpan.FromMilliseconds(1000.0 / fps);
+
+            var ticker = Task.Run(async () =>
+            {
+                int frame = 0;
+                while (!cts.IsCancellationRequested)
+                {
+                    frame++;
+                    lock (renderLock)
+                    {
+                        RebuildProgressLines(frame);
+                    }
+
+                    SplitOutputHelpers.UpdatePanel(layout, "Progress", progressLines,
+                        maxVisibleLines, renderLock, liveCtx);
+
+                    try { await Task.Delay(delay, cts.Token); }
+                    catch (TaskCanceledException) { break; }
+                }
+            }, cts.Token);
+
+            try
+            {
+                await operation(manager);
+            }
+            finally
+            {
+                cts.Cancel();
+                try { await ticker; } catch { }
+            }
         });
         return !hadError;
     }

--- a/Shelly-CLI/ConsoleLayouts/ProgressBarRenderer.cs
+++ b/Shelly-CLI/ConsoleLayouts/ProgressBarRenderer.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using Shelly_CLI.Configuration;
+
+namespace Shelly_CLI.ConsoleLayouts;
+
+public static class ProgressBarRenderer
+{
+    private static readonly char[] Mouth = ['C', 'c'];
+    private const char Body = '-';
+    private const char Pellet = 'o';
+    private const char Empty = ' ';
+
+    public static bool ShouldAnimate(ProgressBarStyleKind style) => style == ProgressBarStyleKind.Pacman;
+
+    public static ProgressBarStyleKind ParseStyle(string? value)
+    {
+        return Enum.TryParse<ProgressBarStyleKind>(value, true, out var s)
+            ? s
+            : ProgressBarStyleKind.Blocks;
+    }
+
+    public static string Render(int pct, int frame, ProgressBarStyleKind style, int width)
+    {
+        pct = Math.Clamp(pct, 0, 100);
+        if (width <= 0)
+        {
+            try { width = Math.Max(10, Console.WindowWidth / 3); }
+            catch { width = 24; }
+        }
+
+        return style switch
+        {
+            ProgressBarStyleKind.Pacman => BuildPacmanBar(pct, frame, width),
+            _ => BuildBlocksBar(pct, width)
+        };
+    }
+
+    public static string RenderStatic(int pct, int width)
+    {
+        pct = Math.Clamp(pct, 0, 100);
+        if (width <= 0) width = 20;
+        return BuildBlocksBar(pct, width);
+    }
+
+    private static string BuildBlocksBar(int pct, int width)
+    {
+        int filled = width * pct / 100;
+        return new string('█', filled) + new string('░', width - filled);
+    }
+
+    private static string BuildPacmanBar(int pct, int frame, int width)
+    {
+        int hashlen = width * pct / 100;
+        var sb = new StringBuilder(width * 8);
+
+        sb.Append("[yellow]");
+        if (hashlen > 0)
+        {
+            int trail = Math.Max(0, hashlen - 1);
+            if (trail > 0) sb.Append(new string(Body, trail));
+
+            if (pct < 100)
+                sb.Append(Mouth[frame & 1]);
+            else
+                sb.Append(Body);
+        }
+        sb.Append("[/]");
+
+        sb.Append("[white]");
+        for (int i = hashlen; i < width; i++)
+        {
+            bool isPelletSlot = ((i - hashlen) % 2 == 0) && pct < 100;
+            sb.Append(isPelletSlot ? Pellet : Empty);
+        }
+        sb.Append("[/]");
+
+        return sb.ToString();
+    }
+}

--- a/Shelly-CLI/ConsoleLayouts/SplitOutput.cs
+++ b/Shelly-CLI/ConsoleLayouts/SplitOutput.cs
@@ -1,4 +1,5 @@
 using PackageManager.Alpm;
+using Shelly_CLI.Configuration;
 using Shelly_CLI.Utility;
 using Spectre.Console;
 
@@ -6,10 +7,25 @@ namespace Shelly_CLI.ConsoleLayouts;
 
 public static class SplitOutput
 {
+    private sealed class BarState
+    {
+        public string Name = "";
+        public ulong Current;
+        public ulong HowMany;
+        public int Pct;
+        public string ActionType = "";
+        public bool Completed;
+    }
+
     public static async Task<bool> Output(IAlpmManager manager, Func<IAlpmManager, Task<bool>> operation, bool noConfirm = false,
         int consoleRation = 3,
         int progressRatio = 2)
     {
+        var cfg = ConfigManager.ReadConfig();
+        var style = ProgressBarRenderer.ParseStyle(cfg.ProgressBarStyle);
+        var fps = Math.Clamp(cfg.ProgressBarFps, 1, 30);
+        var barWidth = cfg.ProgressBarWidth;
+
         var consoleLines = new List<string>();
         var progressLines = new List<string>();
         var maxVisibleLines = Console.WindowHeight - 4; // adjust as needed
@@ -26,23 +42,50 @@ public static class SplitOutput
         layout["Progress"].Update(new Panel("Waiting...").Header("Progress").Expand());
         LiveDisplayContext? liveCtx = null;
         object renderLock = new();
+
+        var rows = new Dictionary<string, BarState>(StringComparer.Ordinal);
+        var order = new List<string>();
+
+        string RenderLine(BarState r, int frame)
+        {
+            var bar = ProgressBarRenderer.Render(r.Pct, frame, style, barWidth);
+            return $"({r.Current}/{r.HowMany}) {r.ActionType} " +
+                   $"[bold]{r.Name.EscapeMarkup()}[/] {bar} {r.Pct,3}%";
+        }
+
+        void RebuildProgressLines(int frame)
+        {
+            progressLines.Clear();
+            foreach (var key in order)
+            {
+                progressLines.Add(RenderLine(rows[key], frame));
+            }
+        }
+
         manager.Progress += (sender, e) =>
         {
             var name = e.PackageName ?? "unknown";
             var pct = e.Percent ?? 0;
-            var bar = new string('█', pct / 5) + new string('░', 20 - pct / 5);
-            var actionType = e.ProgressType;
+            var actionType = e.ProgressType.ToString();
 
-            var line =
-                $"({e.Current}/{e.HowMany}) {actionType} [bold]{name.EscapeMarkup()}[/] [green]{bar}[/] {pct,3}%";
+            lock (renderLock)
+            {
+                if (!rows.TryGetValue(name, out var r))
+                {
+                    r = new BarState { Name = name };
+                    rows[name] = r;
+                    order.Add(name);
+                }
 
-            // Replace last line if same package, otherwise add new line
-            if (progressLines.Count > 0 && progressLines[^1].Contains(name.EscapeMarkup()))
-                progressLines[^1] = line;
-            else
-                progressLines.Add(line);
+                r.Current = e.Current ?? 0;
+                r.HowMany = e.HowMany ?? 0;
+                r.Pct = pct;
+                r.ActionType = actionType;
+                if (pct >= 100) r.Completed = true;
 
-            // Take only the last N lines to simulate scrolling
+                RebuildProgressLines(frame: 0);
+            }
+
             SplitOutputHelpers.UpdatePanel(layout, "Progress", progressLines, maxVisibleLines, renderLock, liveCtx);
         };
 
@@ -151,7 +194,44 @@ public static class SplitOutput
         await AnsiConsole.Live(layout).StartAsync(async ctx =>
         {
             liveCtx = ctx;
-            result = await operation(manager);
+
+            if (!ProgressBarRenderer.ShouldAnimate(style))
+            {
+                result = await operation(manager);
+                return;
+            }
+
+            using var cts = new CancellationTokenSource();
+            var delay = TimeSpan.FromMilliseconds(1000.0 / fps);
+
+            var ticker = Task.Run(async () =>
+            {
+                int frame = 0;
+                while (!cts.IsCancellationRequested)
+                {
+                    frame++;
+                    lock (renderLock)
+                    {
+                        RebuildProgressLines(frame);
+                    }
+
+                    SplitOutputHelpers.UpdatePanel(layout, "Progress", progressLines,
+                        maxVisibleLines, renderLock, liveCtx);
+
+                    try { await Task.Delay(delay, cts.Token); }
+                    catch (TaskCanceledException) { break; }
+                }
+            }, cts.Token);
+
+            try
+            {
+                result = await operation(manager);
+            }
+            finally
+            {
+                cts.Cancel();
+                try { await ticker; } catch { }
+            }
         });
         return result;
     }


### PR DESCRIPTION
- Introduced `ProgressBarRenderer` to centralize progress bar logic.
- Added `ProgressBarStyleKind` for selecting between static and animated styles.
- Enhanced `AurSplitOutput` and `SplitOutput` to enable animation with frame-based rendering.
- Integrated configuration options for bar style, width, and FPS in `ShellyConfig`.
- Updated static progress bar sites to leverage `ProgressBarRenderer.RenderStatic`.