### PR TITLE
Adding an alias command for --version and -v 

### DIFF
--- a/Shelly-CLI/Commands/DefaultCommand.cs
+++ b/Shelly-CLI/Commands/DefaultCommand.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.Design;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using PackageManager.Alpm;
@@ -17,8 +18,14 @@ public class DefaultCommand : AsyncCommand<DefaultCommandSettings>
     //No Confirm is not implemented for default command by design
     public override async Task<int> ExecuteAsync(CommandContext context, [NotNull] DefaultCommandSettings settings)
     {
+        
+        if (settings.Version)
+        {
+            new VersionCommand().Execute(context);
+            return 0;
+        }
+        
         var username = Environment.GetEnvironmentVariable("SUDO_USER") ?? Environment.UserName;
-        ;
         var configPath = Path.Combine("/home", username, ".config", "shelly", "config.json");
         if (!File.Exists(configPath))
         {

--- a/Shelly-CLI/Commands/DefaultCommandSettings.cs
+++ b/Shelly-CLI/Commands/DefaultCommandSettings.cs
@@ -8,4 +8,9 @@ public class DefaultCommandSettings : CommandSettings
     [CommandArgument(0, "[SearchString]")]
     [Description("Search")]
     public string SearchString { get; set; } = string.Empty;
+    
+    [CommandOption("-v | --version")]
+    [Description("Show version information")]
+    public bool Version { get; set; }
+
 }

--- a/Shelly-CLI/Program.cs
+++ b/Shelly-CLI/Program.cs
@@ -94,7 +94,8 @@ public class Program
 
             config.AddCommand<VersionCommand>("version")
                 .WithDescription("Display the application version")
-                .WithExample("version");
+                .WithExample("version")
+                .WithAlias("v");
 
             config.AddCommand<SyncCommand>("sync")
                 .WithDescription("Synchronize package databases")


### PR DESCRIPTION
This PR adds an alias to the -v and --v commands to the **shelly** command so that it correctly triggers a version number when prompted on the CLI.

"shelly -v" or "shelly --version" should trigger the version commmand and display : "shelly version x.x.x"