### PR TITLE
Modify `SetupWindow` behavior to use `contentArea` instead of `mainOv…

### DIFF
--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -283,14 +283,14 @@ sealed class Program
                 var setupWindow = serviceProvider.GetRequiredService<SetupWindow>();
                 var setupWidget = setupWindow.CreateWindow();
                 
-                mainOverlay.AddOverlay(setupWidget);
+                contentArea.Append(setupWidget);
                 currentPage = setupWindow;
 
                 setupWindow.SetupFinished += (_, _) =>
                 {
                     GLib.Functions.IdleAdd(0, () =>
                     {
-                        mainOverlay.RemoveOverlay(setupWidget);
+                        contentArea.Remove(setupWidget);
                         setupWindow.Dispose();
 
                         var homeWindow = serviceProvider.GetRequiredService<HomeWindow>();
@@ -309,8 +309,8 @@ sealed class Program
                 UpdateSelectedButton("HomeButton");
             }
 
-            // Navigate to requested page from CLI args
-            if (_requestedPage != null)
+            // Navigate to requested page from CLI args (ignored during first-launch setup)
+            if (_requestedPage != null && currentPage is not SetupWindow)
             {
                 switch (_requestedPage)
                 {
@@ -503,6 +503,11 @@ sealed class Program
 
             void NavigateWithQuery<T>(string? query, string? buttonId = null) where T : IShellyWindow
             {
+                if (currentPage is SetupWindow)
+                {
+                    return;
+                }
+
                 if (buttonId != null)
                 {
                     UpdateSelectedButton(buttonId);

--- a/Shelly.Gtk/UiFiles/SetupWindow.ui
+++ b/Shelly.Gtk/UiFiles/SetupWindow.ui
@@ -3,6 +3,10 @@
     <requires lib="gtk" version="4.0"/>
     <object class="GtkBox" id="SetupWindow">
         <property name="orientation">vertical</property>
+        <property name="hexpand">true</property>
+        <property name="vexpand">true</property>
+        <property name="halign">fill</property>
+        <property name="valign">fill</property>
         <style>
             <class name="background"/>
         </style>


### PR DESCRIPTION
…erlay` for widget management and refine navigation logic to ignore CLI requests during first-launch setup.