### PR TITLE
Add `PackageSearch` utility for null-safe filtering and refactor pack…

### DIFF
--- a/Shelly-UI.slnx
+++ b/Shelly-UI.slnx
@@ -11,4 +11,5 @@
   <Project Path="Shelly-CLI.Tests/Shelly-CLI.Tests.csproj" />
   <Project Path="Shelly-Notifications/Shelly-Notifications.csproj" />
   <Project Path="Shelly.Gtk/Shelly.Gtk.csproj" />
+  <Project Path="Shelly.Gtk.Tests/Shelly.Gtk.Tests.csproj" />
 </Solution>

--- a/Shelly.Gtk.Tests/PackageSearchTests.cs
+++ b/Shelly.Gtk.Tests/PackageSearchTests.cs
@@ -1,0 +1,149 @@
+using Shelly.Gtk.Helpers;
+
+namespace Shelly.Gtk.Tests;
+
+[TestFixture]
+public class PackageSearchTests
+{
+    // ---- MatchesNameOrDescription -------------------------------------------------
+
+    [Test]
+    public void MatchesNameOrDescription_NullDescription_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() =>
+            PackageSearch.MatchesNameOrDescription("foo", null, "bar"));
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_NullName_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() =>
+            PackageSearch.MatchesNameOrDescription(null, "foo", "bar"));
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_BothNull_EmptySearch_ReturnsTrue()
+    {
+        Assert.That(PackageSearch.MatchesNameOrDescription(null, null, null), Is.True);
+        Assert.That(PackageSearch.MatchesNameOrDescription(null, null, ""), Is.True);
+        Assert.That(PackageSearch.MatchesNameOrDescription(null, null, "   "), Is.True);
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_BothNull_NonEmptySearch_ReturnsFalse()
+    {
+        Assert.That(PackageSearch.MatchesNameOrDescription(null, null, "anything"), Is.False);
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_DescriptionOnlyMatch_ReturnsTrue()
+    {
+        Assert.That(
+            PackageSearch.MatchesNameOrDescription("emby-pac-beta", "AppStream catalog and icons", "appstream"),
+            Is.True);
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_NameOnlyMatch_ReturnsTrue()
+    {
+        Assert.That(
+            PackageSearch.MatchesNameOrDescription("media.emby.client.beta", null, "emby"),
+            Is.True);
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_CaseInsensitive_ReturnsTrue()
+    {
+        Assert.That(
+            PackageSearch.MatchesNameOrDescription("FOO", null, "foo"),
+            Is.True);
+        Assert.That(
+            PackageSearch.MatchesNameOrDescription(null, "FoO BaR", "bar"),
+            Is.True);
+    }
+
+    [Test]
+    public void MatchesNameOrDescription_NoMatch_ReturnsFalse()
+    {
+        Assert.That(
+            PackageSearch.MatchesNameOrDescription("foo", "bar", "baz"),
+            Is.False);
+    }
+
+    // ---- MatchesName --------------------------------------------------------------
+
+    [Test]
+    public void MatchesName_NullName_DoesNotThrow_NonEmptySearch_ReturnsFalse()
+    {
+        Assert.DoesNotThrow(() => PackageSearch.MatchesName(null, "foo"));
+        Assert.That(PackageSearch.MatchesName(null, "foo"), Is.False);
+    }
+
+    [Test]
+    public void MatchesName_EmptySearch_ReturnsTrue()
+    {
+        Assert.That(PackageSearch.MatchesName(null, null), Is.True);
+        Assert.That(PackageSearch.MatchesName(null, ""), Is.True);
+        Assert.That(PackageSearch.MatchesName("anything", "  "), Is.True);
+    }
+
+    [Test]
+    public void MatchesName_CaseInsensitive_ReturnsTrue()
+    {
+        Assert.That(PackageSearch.MatchesName("EmBy", "emby"), Is.True);
+    }
+
+    // ---- MatchesGroup -------------------------------------------------------------
+
+    [Test]
+    public void MatchesGroup_AnyOrEmpty_ReturnsTrue()
+    {
+        Assert.That(PackageSearch.MatchesGroup(null, "Any"), Is.True);
+        Assert.That(PackageSearch.MatchesGroup(null, null), Is.True);
+        Assert.That(PackageSearch.MatchesGroup(null, ""), Is.True);
+        Assert.That(PackageSearch.MatchesGroup(new[] { "g1" }, "Any"), Is.True);
+    }
+
+    [Test]
+    public void MatchesGroup_NullGroups_NonAnySelection_ReturnsFalse()
+    {
+        // emby-pac-beta has no %GROUPS% — must not throw and must filter the row out.
+        Assert.DoesNotThrow(() => PackageSearch.MatchesGroup(null, "default"));
+        Assert.That(PackageSearch.MatchesGroup(null, "default"), Is.False);
+    }
+
+    [Test]
+    public void MatchesGroup_GroupPresent_ReturnsTrue()
+    {
+        Assert.That(PackageSearch.MatchesGroup(new[] { "default", "extra" }, "default"), Is.True);
+    }
+
+    [Test]
+    public void MatchesGroup_GroupAbsent_ReturnsFalse()
+    {
+        Assert.That(PackageSearch.MatchesGroup(new[] { "extra" }, "default"), Is.False);
+    }
+
+    // ---- Regression: the actual EndeavourOS crashing rows --------------------------
+
+    [Test]
+    public void Regression_MediaEmbyClientBeta_NullDescription_NoCrashOnSearch()
+    {
+        // %DESC% is missing → Description is null on the in-memory model.
+        const string? name = "media.emby.client.beta";
+        const string? description = null;
+
+        Assert.DoesNotThrow(() => PackageSearch.MatchesNameOrDescription(name, description, "emby"));
+        Assert.That(PackageSearch.MatchesNameOrDescription(name, description, "emby"), Is.True);
+        Assert.That(PackageSearch.MatchesNameOrDescription(name, description, "zzz"), Is.False);
+    }
+
+    [Test]
+    public void Regression_EmbyPacBeta_NullGroups_NoCrashOnGroupFilter()
+    {
+        // %GROUPS% missing → Groups is null on the in-memory model.
+        Assert.DoesNotThrow(() => PackageSearch.MatchesGroup(null, "default"));
+        Assert.That(PackageSearch.MatchesGroup(null, "default"), Is.False);
+        Assert.That(PackageSearch.MatchesGroup(null, "Any"), Is.True);
+    }
+}

--- a/Shelly.Gtk.Tests/Shelly.Gtk.Tests.csproj
+++ b/Shelly.Gtk.Tests/Shelly.Gtk.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Shelly.Gtk.Tests</RootNamespace>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <!-- Disable AOT/trim/single-file inherited from referenced project. -->
+        <PublishAot>false</PublishAot>
+        <PublishSingleFile>false</PublishSingleFile>
+        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Shelly.Gtk\Shelly.Gtk.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Shelly.Gtk/Helpers/PackageSearch.cs
+++ b/Shelly.Gtk/Helpers/PackageSearch.cs
@@ -1,0 +1,54 @@
+using GObject;
+using Gtk;
+
+namespace Shelly.Gtk.Helpers;
+
+
+internal static class PackageSearch
+{
+
+    public static bool MatchesNameOrDescription(string? name, string? description, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+            return true;
+
+        const StringComparison cmp = StringComparison.OrdinalIgnoreCase;
+        return (name ?? string.Empty).Contains(search, cmp)
+               || (description ?? string.Empty).Contains(search, cmp);
+    }
+
+    public static bool MatchesName(string? name, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+            return true;
+
+        return (name ?? string.Empty)
+            .Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    public static bool MatchesGroup(IEnumerable<string>? groups, string? selectedGroup)
+    {
+        if (string.IsNullOrEmpty(selectedGroup) || selectedGroup == "Any")
+            return true;
+
+        return groups is not null && groups.Contains(selectedGroup);
+    }
+
+
+    public static CustomFilter CreateSafeFilter(Func<GObject.Object, bool> predicate)
+    {
+        return CustomFilter.New(obj =>
+        {
+            try
+            {
+                return predicate(obj);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[Shelly] FilterPackage threw, hiding row: {ex}");
+                return false;
+            }
+        });
+    }
+}

--- a/Shelly.Gtk/Shelly.Gtk.csproj
+++ b/Shelly.Gtk/Shelly.Gtk.csproj
@@ -31,6 +31,10 @@
         <EmbeddedResource Include="UiFiles\**\*.ui" />
         <EmbeddedResource Include="Assets\chel-intro.png" />
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Shelly.Gtk.Tests" />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="GirCore.Gtk-4.0" Version="0.8.0-preview.1" />
         <PackageReference Include="GirCore.GObject-2.0.Integration" Version="0.8.0-preview.1"/>

--- a/Shelly.Gtk/Windows/AUR/AurRemove.cs
+++ b/Shelly.Gtk/Windows/AUR/AurRemove.cs
@@ -68,7 +68,7 @@ public class AurRemove(
         _cascadeDeleteCheck = (CheckButton)builder.GetObject("cascade_delete_check")!;
         _showHiddenCheck = (CheckButton)builder.GetObject("show_hidden_check")!;
         _listStore = Gio.ListStore.New(AurPackageGObject.GetGType());
-        _filter = CustomFilter.New(FilterPackage);
+        _filter = PackageSearch.CreateSafeFilter(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
@@ -118,11 +118,10 @@ public class AurRemove(
 
     private bool FilterPackage(GObject.Object obj)
     {
-        if (obj is not AurPackageGObject pkgObj || pkgObj.Package == null)
+        if (obj is not AurPackageGObject { Package: { } pkg })
             return false;
 
-        return string.IsNullOrWhiteSpace(_searchText) ||
-               pkgObj.Package.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+        return PackageSearch.MatchesName(pkg.Name, _searchText);
     }
 
     private void ApplyFilter()

--- a/Shelly.Gtk/Windows/AUR/AurUpdate.cs
+++ b/Shelly.Gtk/Windows/AUR/AurUpdate.cs
@@ -74,7 +74,7 @@ public class AurUpdate(
         _updateButton.SetSensitive(false);
 
         _listStore = Gio.ListStore.New(AurUpdateGObject.GetGType());
-        _filter = CustomFilter.New(FilterPackage);
+        _filter = PackageSearch.CreateSafeFilter(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
@@ -124,11 +124,10 @@ public class AurUpdate(
 
     private bool FilterPackage(GObject.Object obj)
     {
-        if (obj is not AurUpdateGObject pkgObj || pkgObj.Package == null)
+        if (obj is not AurUpdateGObject { Package: { } pkg })
             return false;
 
-        return string.IsNullOrWhiteSpace(_searchText) ||
-               pkgObj.Package.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+        return PackageSearch.MatchesName(pkg.Name, _searchText);
     }
 
     private void ApplyFilter()

--- a/Shelly.Gtk/Windows/Flatpak/FlatpakInstall.cs
+++ b/Shelly.Gtk/Windows/Flatpak/FlatpakInstall.cs
@@ -235,7 +235,7 @@ public class FlatpakInstall(
         _installFromFlatpakRef.OnClicked += (_, _) => { _ = InstallFromFlatpakRef(); };
 
         _listStore = Gio.ListStore.New(FlatpakGObject.GetGType());
-        _filter = CustomFilter.New(FilterPackage);
+        _filter = PackageSearch.CreateSafeFilter(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _gridView.SetModel(_selectionModel);
@@ -571,23 +571,24 @@ public class FlatpakInstall(
 
     private bool FilterPackage(GObject.Object obj)
     {
-        if (obj is not FlatpakGObject pkgObj || pkgObj.Package == null) return false;
+        if (obj is not FlatpakGObject { Package: { } pkg }) return false;
 
+        var id = pkg.Id ?? string.Empty;
         switch (_selectedCategory)
         {
             case FlatpakCategories.AllApplications:
                 break;
             case FlatpakCategories.Recommended:
-                if (!_trendingApps.Contains(pkgObj.Package.Id)) return false;
+                if (!_trendingApps.Contains(id)) return false;
                 break;
             case FlatpakCategories.MostWanted:
-                if (!_popularApps.Contains(pkgObj.Package.Id)) return false;
+                if (!_popularApps.Contains(id)) return false;
                 break;
             case FlatpakCategories.RecentlyAdded:
-                if (!_recentlyAddedApps.Contains(pkgObj.Package.Id)) return false;
+                if (!_recentlyAddedApps.Contains(id)) return false;
                 break;
             case FlatpakCategories.RecentlyUpdated:
-                if (!_recentlyUpdatedApps.Contains(pkgObj.Package.Id)) return false;
+                if (!_recentlyUpdatedApps.Contains(id)) return false;
                 break;
             case FlatpakCategories.AudioVideo:
             case FlatpakCategories.Development:
@@ -602,17 +603,15 @@ public class FlatpakInstall(
             default:
             {
                 var categoryName = _selectedCategory.ToString();
-                var result = pkgObj.Package.Categories.Contains(categoryName, StringComparer.OrdinalIgnoreCase);
+                var categories = pkg.Categories;
+                var result = categories is not null &&
+                             categories.Contains(categoryName, StringComparer.OrdinalIgnoreCase);
                 if (!result) return false;
                 break;
             }
         }
 
-        if (string.IsNullOrWhiteSpace(_searchText))
-            return true;
-
-        return pkgObj.Package.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
-               pkgObj.Package.Description.Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+        return PackageSearch.MatchesNameOrDescription(pkg.Name, pkg.Description, _searchText);
     }
 
     private void SetUrlLinks(Dictionary<string, string>? urls)

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -90,7 +90,7 @@ public class PackageInstall(
         _showHiddenCheck = (CheckButton)_builder.GetObject("show_hidden_check")!;
 
         _listStore = Gio.ListStore.New(AlpmPackageGObject.GetGType());
-        _filter = CustomFilter.New(FilterPackage);
+        _filter = PackageSearch.CreateSafeFilter(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
@@ -624,18 +624,13 @@ public class PackageInstall(
 
     private bool FilterPackage(GObject.Object obj)
     {
-        if (obj is not AlpmPackageGObject pkgObj || pkgObj.Package == null) return false;
-
-        if (_selectedGroup != "Any" && !(pkgObj.Package?.Groups.Contains(_selectedGroup) ?? false))
-        {
+        if (obj is not AlpmPackageGObject { Package: { } pkg })
             return false;
-        }
 
-        if (string.IsNullOrWhiteSpace(_searchText))
-            return true;
+        if (!PackageSearch.MatchesGroup(pkg.Groups, _selectedGroup))
+            return false;
 
-        return (pkgObj.Package?.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false) ||
-               (pkgObj.Package?.Description.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false);
+        return PackageSearch.MatchesNameOrDescription(pkg.Name, pkg.Description, _searchText);
     }
 
 

--- a/Shelly.Gtk/Windows/Packages/PackageManagement.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageManagement.cs
@@ -87,7 +87,7 @@ public class PackageManagement(
         _removeButton.SetSensitive(false);
 
         _listStore = Gio.ListStore.New(AlpmPackageGObject.GetGType());
-        _filter = CustomFilter.New(FilterPackage);
+        _filter = PackageSearch.CreateSafeFilter(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
@@ -606,21 +606,13 @@ public class PackageManagement(
 
     private bool FilterPackage(GObject.Object obj)
     {
-        if (obj is AlpmPackageGObject { Package: not null } pkgObj)
-        {
-            if (_selectedGroup != "Any" && !(pkgObj.Package?.Groups.Contains(_selectedGroup) ?? false))
-            {
-                return false;
-            }
+        if (obj is not AlpmPackageGObject { Package: { } pkg })
+            return false;
 
-            if (string.IsNullOrWhiteSpace(_searchText))
-                return true;
+        if (!PackageSearch.MatchesGroup(pkg.Groups, _selectedGroup))
+            return false;
 
-            return (pkgObj.Package?.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                   (pkgObj.Package?.Description.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false);
-        }
-
-        return false;
+        return PackageSearch.MatchesNameOrDescription(pkg.Name, pkg.Description, _searchText);
     }
 
     private async Task LoadDataAsync(CancellationToken ct = default)

--- a/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
@@ -80,7 +80,7 @@ public class PackageUpdate(
         _detailRevealer = (Revealer)builder.GetObject("detail_revealer")!;
         _detailBox = (Box)builder.GetObject("detail_box")!;
         _listStore = Gio.ListStore.New(AlpmUpdateGObject.GetGType());
-        _filter = CustomFilter.New(FilterPackage);
+        _filter = PackageSearch.CreateSafeFilter(FilterPackage);
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
@@ -543,13 +543,10 @@ public class PackageUpdate(
 
     private bool FilterPackage(GObject.Object obj)
     {
-        if (obj is not AlpmUpdateGObject pkgObj || pkgObj.Package == null)
+        if (obj is not AlpmUpdateGObject { Package: { } pkg })
             return false;
 
-        if (string.IsNullOrWhiteSpace(_searchText))
-            return true;
-
-        return pkgObj.Package?.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ?? false;
+        return PackageSearch.MatchesName(pkg.Name, _searchText);
     }
 
     private async Task LoadDataAsync(CancellationToken ct = default)


### PR DESCRIPTION
…age filtering logic across AUR, Flatpak, and ALPM windows. Introduce `Shelly.Gtk.Tests` project with comprehensive test coverage for `PackageSearch`.