### PR TITLE
Changing SingleSelection property "Autoselect" from "false" to "true"

### DIFF
--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -86,7 +86,7 @@ public class AurInstall(
         _listStore = Gio.ListStore.New(AurPackageGObject.GetGType());
         _selectionModel = SingleSelection.New(_listStore);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
         _searchForPackageLabel = (Label)builder.GetObject("search_overlay")!;
         _searchForPackageLabel.Label_ = "<span size='large'>Search for AUR packages</span>";

--- a/Shelly.Gtk/Windows/AUR/AurRemove.cs
+++ b/Shelly.Gtk/Windows/AUR/AurRemove.cs
@@ -73,7 +73,7 @@ public class AurRemove(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _versionColumn);

--- a/Shelly.Gtk/Windows/AUR/AurUpdate.cs
+++ b/Shelly.Gtk/Windows/AUR/AurUpdate.cs
@@ -79,7 +79,7 @@ public class AurUpdate(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _versionColumn);

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -95,7 +95,7 @@ public class PackageInstall(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _sizeColumn, _versionColumn, _repositoryColumn);

--- a/Shelly.Gtk/Windows/Packages/PackageManagement.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageManagement.cs
@@ -92,7 +92,7 @@ public class PackageManagement(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
         _groupDropDown = (DropDown)builder.GetObject("grouping_selection")!;
         _detailRevealer = (Revealer)builder.GetObject("detail_revealer")!;

--- a/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
@@ -85,7 +85,7 @@ public class PackageUpdate(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _sizeDiffColumn, _oldColumn, _versionColumn);


### PR DESCRIPTION
This PR changes the default selection behaviour in package selection screens to remove persistance of an unrelated entry when alternating between different pages. 

Now, when switching from one screen to another, the first package will be selected by default:

<img width="1683" height="1434" alt="image" src="https://github.com/user-attachments/assets/ad4f6fe7-144b-470a-a739-34d6e3299fa7" />

If the user selects any option, and then switches to another screen, it will automatically pick the first option, instead of repeating an entry that is no longer there:

<img width="1686" height="1439" alt="image" src="https://github.com/user-attachments/assets/f13a7ea7-f3cd-4a5c-ac95-ffaf5974ec32" />
