### PR TITLE
Adding a PKGBUILD preview window

### DIFF
--- a/Shelly.Gtk/Assets/style.css
+++ b/Shelly.Gtk/Assets/style.css
@@ -134,7 +134,7 @@ button.package-detail-expander {
     padding: 8px 12px;
     font-weight: bold;
     color: alpha(@theme_selected_bg_color, 0.8);
-    background-color: alpha(currentColor, 0.02);
+    background-color: alpha(@theme_selected_bg_color, 0.02);
     box-shadow: none;
     border-radius: 8px;
 }

--- a/Shelly.Gtk/Assets/style.css
+++ b/Shelly.Gtk/Assets/style.css
@@ -129,10 +129,14 @@ scrolledwindow > scrollbar {
     background-color: alpha(currentColor, 0.05);
 }
 
-.package-detail-expander > box:first-child {
+.package-detail-expander > box:first-child,
+button.package-detail-expander {
     padding: 8px 12px;
     font-weight: bold;
     color: alpha(currentColor, 0.8);
+    background-color: alpha(currentColor, 0.02);
+    box-shadow: none;
+    border-radius: 8px;
 }
 
 .package-detail-expander > box {
@@ -140,7 +144,7 @@ scrolledwindow > scrollbar {
 }
 
 .package-chip {
-    background-color: alpha(currentColor, 0.05);
+    background-color: transparent;
     border: 1px solid alpha(currentColor, 0.1);
     border-radius: 6px;
     padding: 2px 8px;

--- a/Shelly.Gtk/ServiceBuilder.cs
+++ b/Shelly.Gtk/ServiceBuilder.cs
@@ -20,6 +20,7 @@ public static class ServiceBuilder
         collection.AddSingleton<ICredentialManager, CredentialManager>();
         collection.AddSingleton<IAlpmEventService, AlpmEventService>();
         collection.AddSingleton<IConfigService, ConfigService>();
+        collection.AddSingleton<IPkgBuildService, PkgBuildService>();
         collection.AddSingleton<IGenericQuestionService, GenericQuestionService>();
         collection.AddSingleton<IDirtyService, DirtyService>();
         collection.AddSingleton<ILockoutService, LockoutService>();

--- a/Shelly.Gtk/Services/IPkgBuildService.cs
+++ b/Shelly.Gtk/Services/IPkgBuildService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Gtk; // Certifique-se de ser Gtk puro, não Gtk.Internal
+
+namespace Shelly.Gtk.Services;
+
+public interface IPkgBuildService
+{
+    // Agora a assinatura está completa e reconhecível pelo compilador
+    Task ShowPreviewAsync(Overlay overlay, string packageName);
+}

--- a/Shelly.Gtk/Services/IPkgBuildService.cs
+++ b/Shelly.Gtk/Services/IPkgBuildService.cs
@@ -1,10 +1,9 @@
 using System.Threading.Tasks;
-using Gtk; // Certifique-se de ser Gtk puro, não Gtk.Internal
+using Gtk; 
 
 namespace Shelly.Gtk.Services;
 
 public interface IPkgBuildService
 {
-    // Agora a assinatura está completa e reconhecível pelo compilador
-    Task ShowPreviewAsync(Overlay overlay, string packageName);
+    Task ShowPreviewAsync(Overlay overlay, string packageName, IGenericQuestionService questionService);
 }

--- a/Shelly.Gtk/Services/PkgBuildService.cs
+++ b/Shelly.Gtk/Services/PkgBuildService.cs
@@ -8,7 +8,7 @@ public class PkgBuildService : IPkgBuildService
 {
     private readonly HttpClient _httpClient = new();
 
-    public async Task ShowPreviewAsync(Overlay parentOverlay, string packageName)
+    public async Task ShowPreviewAsync(Overlay parentOverlay, string packageName, IGenericQuestionService questionService)
     {
         try
         {
@@ -19,7 +19,7 @@ public class PkgBuildService : IPkgBuildService
             {
                 var args = new PackageBuildEventArgs($"PKGBUILD: {packageName}", content);
             
-                PkgbuildPreview.ShowPackageBuildPreview(parentOverlay, args);
+                PkgbuildPreview.ShowPackageBuildPreview(parentOverlay, args, questionService);
             
                 return false; 
             });

--- a/Shelly.Gtk/Services/PkgBuildService.cs
+++ b/Shelly.Gtk/Services/PkgBuildService.cs
@@ -1,0 +1,32 @@
+using Gtk;
+using Shelly.Gtk.Windows.Dialog;
+using Shelly.Gtk.UiModels;
+
+namespace Shelly.Gtk.Services;
+
+public class PkgBuildService : IPkgBuildService
+{
+    private readonly HttpClient _httpClient = new();
+
+    public async Task ShowPreviewAsync(Overlay parentOverlay, string packageName)
+    {
+        try
+        {
+            string url = $"https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h={packageName}";
+            string content = await _httpClient.GetStringAsync(url);
+            
+            GLib.Functions.IdleAdd(0, () => 
+            {
+                var args = new PackageBuildEventArgs($"PKGBUILD: {packageName}", content);
+            
+                PkgbuildPreview.ShowPackageBuildPreview(parentOverlay, args);
+            
+                return false; 
+            });
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Erro no serviço: {ex.Message}");
+        }
+    }
+}

--- a/Shelly.Gtk/Services/PkgBuildService.cs
+++ b/Shelly.Gtk/Services/PkgBuildService.cs
@@ -13,7 +13,27 @@ public class PkgBuildService : IPkgBuildService
         try
         {
             string url = $"https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h={packageName}";
-            string content = await _httpClient.GetStringAsync(url);
+            using var response = await _httpClient.GetAsync(url);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                GLib.Functions.IdleAdd(0, () => {
+                    questionService.RaiseToastMessage(new ToastMessageEventArgs($"PKGBUILD for '{packageName}' not found."));
+                    return false;
+                });      
+                return;
+            }
+            
+            var content = await response.Content.ReadAsStringAsync();
+            
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                GLib.Functions.IdleAdd(0, () => {
+                    questionService.RaiseToastMessage(new ToastMessageEventArgs("The PKGBUILD is empty."));
+                    return false;
+                });                
+                return;
+            }
             
             GLib.Functions.IdleAdd(0, () => 
             {

--- a/Shelly.Gtk/UiFiles/AUR/AurWindow.ui
+++ b/Shelly.Gtk/UiFiles/AUR/AurWindow.ui
@@ -1,71 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <requires lib="gtk" version="4.0"/>
-    <object class="GtkBox" id="AurInstallWindow">
-        <property name="orientation">vertical</property>
+    <object class="GtkOverlay" id="main_overlay">
         <child>
-            <object class="GtkBox">
-                <property name="halign">baseline</property>
-                <property name="margin-bottom">10</property>
-                <property name="margin-top">10</property>
-                <property name="margin-start">10</property>
-                <property name="margin-end">10</property>
-                <property name="spacing">5</property>
-                <child>
-                    <object class="GtkButton" id="install_button">
-                        <property name="halign">start</property>
-                        <property name="label">Install Aur Package(s)</property>
-                        <style>
-                            <class name="suggested-action"/>
-                        </style>
-                    </object>
-                </child>
+            <object class="GtkBox" id="AurInstallWindow">
+                <property name="orientation">vertical</property>
                 <child>
                     <object class="GtkBox">
+                        <property name="halign">baseline</property>
+                        <property name="margin-bottom">10</property>
+                        <property name="margin-top">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="spacing">5</property>
+                        <child>
+                            <object class="GtkButton" id="install_button">
+                                <property name="halign">start</property>
+                                <property name="label">Install Aur Package(s)</property>
+                                <style>
+                                    <class name="suggested-action"/>
+                                </style>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkBox">
+                                <property name="hexpand">true</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkCheckButton" id="chroot_check">
+                                <property name="label">Use chroot</property>
+                                <property name="tooltip-text">Build packages in a clean chroot environment</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkCheckButton" id="run_checks_check">
+                                <property name="label">Run checks</property>
+                                <property name="tooltip-text">Run the --check function during package build (installs checkdepends)</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkSearchEntry" id="search_entry">
+                                <property name="placeholder-text">Search packages...</property>
+                                <property name="width-request">200</property>
+                                <style>
+                                    <class name="spaced-search"/>
+                                </style>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkButton" id="search_button">
+                                <property name="icon-name">system-search-symbolic</property>
+                                <property name="tooltip-text">search</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <child>
+                    <object class="GtkBox" id="detail_hbox">
                         <property name="hexpand">true</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkCheckButton" id="chroot_check">
-                        <property name="label">Use chroot</property>
-                        <property name="tooltip-text">Build packages in a clean chroot environment</property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkCheckButton" id="run_checks_check">
-                        <property name="label">Run checks</property>
-                        <property name="tooltip-text">Run the --check function during package build (installs
-                            checkdepends)
-                        </property>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkSearchEntry" id="search_entry">
-                        <property name="placeholder-text">Search packages...</property>
-                        <property name="width-request">200</property>
-                        <style>
-                            <class name="spaced-search"/>
-                        </style>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkButton" id="search_button">
-                        <property name="icon-name">system-search-symbolic</property>
-                        <property name="tooltip-text">search</property>
-                    </object>
-                </child>
-            </object>
-        </child>
-        <child>
-            <object class="GtkBox" id="detail_hbox">
-                <property name="hexpand">true</property>
-                <property name="orientation">horizontal</property>
-                <property name="vexpand">true</property>
-                <property name="margin-start">10</property>
-                <property name="margin-end">10</property>
-                <property name="margin-bottom">10</property>
-                <child>
-                    <object class="GtkOverlay">
+                        <property name="orientation">horizontal</property>
+                        <property name="vexpand">true</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-bottom">10</property>
                         <child>
                             <object class="GtkScrolledWindow">
                                 <property name="hexpand">true</property>
@@ -99,56 +97,44 @@
                                                 <property name="title">Popularity</property>
                                             </object>
                                         </child>
-
                                         <child>
                                             <object class="GtkColumnViewColumn" id="version_column">
                                                 <property name="title">Version</property>
                                                 <property name="expand">true</property>
                                             </object>
                                         </child>
-                                        
                                     </object>
                                 </child>
                             </object>
                         </child>
-
-                        <child type="overlay">
-                            <object class="GtkLabel" id="search_overlay">
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="opacity">0.5</property>
-                                <property name="visible">false</property>
-                                <property name="use-markup">true</property>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-                <child>
-                    <object class="GtkRevealer" id="detail_revealer">
-                        <property name="reveal-child">false</property>
-                        <property name="transition-type">slide-left</property>
                         <child>
-                            <object class="GtkFrame">
-                                <property name="width-request">300</property>
-                                <property name="margin-start">12</property>
-                                <style>
-                                    <class name="rounded-card"/>
-                                </style>
+                            <object class="GtkRevealer" id="detail_revealer">
+                                <property name="reveal-child">false</property>
+                                <property name="transition-type">slide-left</property>
                                 <child>
-                                    <object class="GtkScrolledWindow">
-                                        <property name="hscrollbar-policy">never</property>
-                                        <property name="overlay-scrolling">true</property>
-                                        <property name="propagate-natural-height">True</property>
-                                        <property name="propagate-natural-width">False</property>
-                                        <property name="vexpand">true</property>
+                                    <object class="GtkFrame">
+                                        <property name="width-request">300</property>
+                                        <property name="margin-start">12</property>
+                                        <style>
+                                            <class name="rounded-card"/>
+                                        </style>
                                         <child>
-                                            <object class="GtkBox" id="detail_box">
-                                                <property name="margin-bottom">10</property>
-                                                <property name="margin-end">10</property>
-                                                <property name="margin-start">10</property>
-                                                <property name="margin-top">10</property>
-                                                <property name="orientation">vertical</property>
-                                                <property name="spacing">8</property>
+                                            <object class="GtkScrolledWindow">
+                                                <property name="hscrollbar-policy">never</property>
+                                                <property name="overlay-scrolling">true</property>
+                                                <property name="propagate-natural-height">True</property>
+                                                <property name="propagate-natural-width">False</property>
+                                                <property name="vexpand">true</property>
+                                                <child>
+                                                    <object class="GtkBox" id="detail_box">
+                                                        <property name="margin-bottom">10</property>
+                                                        <property name="margin-end">10</property>
+                                                        <property name="margin-start">10</property>
+                                                        <property name="margin-top">10</property>
+                                                        <property name="orientation">vertical</property>
+                                                        <property name="spacing">8</property>
+                                                    </object>
+                                                </child>
                                             </object>
                                         </child>
                                     </object>
@@ -157,6 +143,15 @@
                         </child>
                     </object>
                 </child>
+            </object>
+        </child>
+        <child type="overlay">
+            <object class="GtkLabel" id="search_overlay">
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="opacity">0.5</property>
+                <property name="visible">false</property>
+                <property name="use-markup">true</property>
             </object>
         </child>
     </object>

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -537,8 +537,13 @@ public class AurInstall(
         // pkgbuild preview button
         var pkgBuildButton = Button.New();
         pkgBuildButton.SetName("Package Build");
-        pkgBuildButton.SetLabel("Preview Pkgbuild");
-        pkgBuildButton.Halign = Align.BaselineFill;
+        pkgBuildButton.SetLabel("Preview PKGBUILD");
+        pkgBuildButton.Halign = Align.Fill;
+        if (pkgBuildButton.Child is Label label)
+        {
+            label.Xalign = 0; 
+        }
+        pkgBuildButton.Valign = Align.Start;
         pkgBuildButton.AddCssClass("package-detail-expander");
         pkgBuildButton.TooltipText = "Displays Package Build";
         pkgBuildButton.OnClicked += OnPkgBuildClicked;

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -533,7 +533,7 @@ public class AurInstall(
         pkgBuildButton.SetName("Package Build");
         pkgBuildButton.SetLabel("Preview Pkgbuild");
         pkgBuildButton.Halign = Align.BaselineFill;
-        pkgBuildButton.AddCssClass("label");
+        pkgBuildButton.AddCssClass("package-detail-expander");
         pkgBuildButton.TooltipText = "Displays Package Build";
         pkgBuildButton.OnClicked += (_, _) =>
         {

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Xml;
 using GObject;
 using Gtk;
 using Shelly.Gtk.Helpers;
@@ -526,7 +527,19 @@ public class AurInstall(
         {
             _detailBox.Remove(child);
         }
+        
+        // pkgbuild preview button
+        var pkgBuildButton = Button.New();
+        pkgBuildButton.SetName("Package Build");
+        pkgBuildButton.SetLabel("Preview Pkgbuild");
+        pkgBuildButton.Halign = Align.BaselineFill;
+        pkgBuildButton.AddCssClass("label");
+        pkgBuildButton.TooltipText = "Displays Package Build";
+        pkgBuildButton.OnClicked += (_, _) =>
+        {
 
+        };
+        
         var backButton = Button.New();
         backButton.SetIconName("go-next-symbolic");
         backButton.Halign = Align.Start;
@@ -564,7 +577,7 @@ public class AurInstall(
             row.Append(valueWidget);
             _detailBox.Append(row);
         }
-
+        
         var headerBox = Box.New(Orientation.Vertical, 4);
         headerBox.MarginBottom = 16;
         headerBox.MarginTop = 8;
@@ -633,6 +646,8 @@ public class AurInstall(
             row.Append(valueWidget);
             _detailBox.Append(row);
         }
+        
+        _detailBox.Append(pkgBuildButton);
 
         if (pkg.Depends?.Count > 0)
         {

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -766,7 +766,7 @@ public class AurInstall(
             
             var package = _currentDetailPkg?.Package?.Name;
 
-            await pkgBuildService.ShowPreviewAsync(_mainOverlay!, package!);
+            await pkgBuildService.ShowPreviewAsync(_mainOverlay!, package!, genericQuestionService);
         }
         finally 
         {

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -19,6 +19,7 @@ namespace Shelly.Gtk.Windows.AUR;
 public class AurInstall(
     IPrivilegedOperationService privilegedOperationService,
     ILockoutService lockoutService,
+    IPkgBuildService pkgBuildService,
     IConfigService configService,
     IGenericQuestionService genericQuestionService,
     IDirtyService dirtyService) : IShellyWindow, IReloadable
@@ -42,6 +43,7 @@ public class AurInstall(
     private Box _detailBox = null!;
     private AurPackageGObject? _currentDetailPkg;
     private Revealer _detailRevealer = null!;
+    private Overlay? _mainOverlay = null!;
 
     private Dictionary<ColumnViewCell, (SignalHandler<CheckButton> OnToggled, EventHandler OnExternalToggle)>
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
@@ -62,10 +64,14 @@ public class AurInstall(
     public Widget CreateWindow()
     {
         var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/AUR/AurWindow.ui"), -1);
+        var rootOverlay = (Overlay)builder.GetObject("main_overlay")!;
+        _mainOverlay = rootOverlay;
         _box = (Box)builder.GetObject("AurInstallWindow")!;
         _columnView = (ColumnView)builder.GetObject("package_grid")!;
         _searchEntry = (SearchEntry)builder.GetObject("search_entry")!;
 
+        _mainOverlay = (Overlay)builder.GetObject("main_overlay")!;
+        
         _checkColumn = (ColumnViewColumn)builder.GetObject("check_column")!;
         _checkColumn.Resizable = true;
 
@@ -183,7 +189,7 @@ public class AurInstall(
             }
         };
 
-        return _box;
+        return _mainOverlay;
     }
     
     private PackageSortColumn? GetSortColumn(ColumnViewColumn column)
@@ -535,10 +541,7 @@ public class AurInstall(
         pkgBuildButton.Halign = Align.BaselineFill;
         pkgBuildButton.AddCssClass("package-detail-expander");
         pkgBuildButton.TooltipText = "Displays Package Build";
-        pkgBuildButton.OnClicked += (_, _) =>
-        {
-
-        };
+        pkgBuildButton.OnClicked += OnPkgBuildClicked;
         
         var backButton = Button.New();
         backButton.SetIconName("go-next-symbolic");
@@ -752,6 +755,25 @@ public class AurInstall(
             _detailBox.Append(expander);
         }
     }
+    
+    private async void OnPkgBuildClicked(object? sender, EventArgs e)
+    {
+        if (_currentDetailPkg == null) return;
+
+        try 
+        {
+            ((Button)sender!).Sensitive = false;
+            
+            var package = _currentDetailPkg?.Package?.Name;
+
+            await pkgBuildService.ShowPreviewAsync(_mainOverlay!, package!);
+        }
+        finally 
+        {
+            ((Button)sender!).Sensitive = true;
+        }
+    }
+    
 
     public void Reload()
     {

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -39,13 +39,11 @@ public static class PkgbuildPreview
 
         var closeButton = Button.New();
         closeButton.SetIconName("window-close-symbolic");
-        closeButton.AddCssClass("flat"); 
         closeButton.TooltipText = "Close Preview";
         closeButton.OnClicked += (_, _) => Close();
         
         var copyButton = Button.New();
         copyButton.SetIconName("edit-copy-symbolic"); 
-        copyButton.AddCssClass("flat");
         copyButton.TooltipText = "Copy PKGBUILD to clipboard";
         copyButton.OnClicked += (_, _) =>
         {

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -1,0 +1,109 @@
+using Gtk;
+using Pango;
+using Shelly.Gtk.UiModels;
+using WrapMode = Gtk.WrapMode;
+
+namespace Shelly.Gtk.Windows.Dialog;
+
+public static class PkgbuildPreview
+{
+    public static void ShowPackageBuildPreview(Overlay parentOverlay, PackageBuildEventArgs e)
+    {
+        var background = Box.New(Orientation.Horizontal, 0);
+        background.AddCssClass("lockout-overlay");
+        background.SetHalign(Align.Fill);
+        background.SetValign(Align.Fill);
+        background.SetHexpand(true);
+        background.SetVexpand(true);
+
+        var baseFrame = Frame.New(null);
+        baseFrame.SetHalign(Align.Center);
+        baseFrame.SetValign(Align.Center);
+        baseFrame.SetSizeRequest(800, 720); 
+        baseFrame.SetMarginTop(20);
+        baseFrame.SetMarginBottom(20);
+        baseFrame.SetMarginStart(20);
+        baseFrame.SetMarginEnd(20);
+        baseFrame.AddCssClass("background");
+        baseFrame.AddCssClass("dialog-overlay");
+        baseFrame.SetOverflow(Overflow.Hidden);
+        background.Append(baseFrame);
+
+        var box = Box.New(Orientation.Vertical, 12);
+        baseFrame.SetChild(box);
+
+        var headerBox = Box.New(Orientation.Horizontal, 0);
+        headerBox.SetMarginTop(4);
+        headerBox.SetMarginStart(4);
+
+        var closeButton = Button.New();
+        closeButton.SetIconName("window-close-symbolic");
+        closeButton.AddCssClass("flat"); 
+        closeButton.TooltipText = "Close Preview";
+        closeButton.OnClicked += (_, _) => Close();
+        
+        var copyButton = Button.New();
+        copyButton.SetIconName("edit-copy-symbolic"); 
+        copyButton.AddCssClass("flat");
+        copyButton.TooltipText = "Copy PKGBUILD to clipboard";
+        copyButton.OnClicked += (_, _) =>
+        {
+            var clipboard = copyButton.GetClipboard();
+            clipboard.SetText(e.PkgBuild);
+        };
+
+        var titleLabel = Label.New(e.Title);
+        titleLabel.AddCssClass("title-4");
+        titleLabel.SetHexpand(true);
+        titleLabel.SetHalign(Align.Center);
+        titleLabel.SetXalign(0.5f);
+        titleLabel.SetMarginEnd(40);
+
+        headerBox.Append(copyButton);
+        headerBox.Append(titleLabel);
+        headerBox.Append(closeButton);
+
+        box.Append(headerBox);
+        
+
+        var textView = TextView.New();
+        textView.SetWrapMode(WrapMode.WordChar);
+        textView.Editable = false;          
+        textView.Monospace = true;        
+        textView.CursorVisible = false;
+        textView.LeftMargin = 12;
+        textView.RightMargin = 12;
+        textView.TopMargin = 12;
+        textView.BottomMargin = 12;
+        
+        textView.GetBuffer().SetText(e.PkgBuild, -1);
+
+        var scrolledWindow = ScrolledWindow.New();
+        scrolledWindow.SetPolicy(PolicyType.Automatic, PolicyType.Automatic);
+        scrolledWindow.SetVexpand(true);
+        scrolledWindow.SetHexpand(true);
+        scrolledWindow.AddCssClass("view"); 
+        scrolledWindow.SetChild(textView);
+        
+        box.Append(scrolledWindow);
+
+        var shortcutController = ShortcutController.New();
+        shortcutController.Scope = ShortcutScope.Global;
+        
+        var escAction = CallbackAction.New((_, _) => {
+            Close();
+            return true;
+        });
+        shortcutController.AddShortcut(Shortcut.New(ShortcutTrigger.ParseString("Escape"), escAction));
+        background.AddController(shortcutController);
+
+        parentOverlay.AddOverlay(background);
+        return;
+
+        void Close()
+        {
+            e.SetResponse(false);
+            parentOverlay.RemoveOverlay(background);
+        }
+    }
+}

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -1,5 +1,6 @@
 using Gtk;
 using Pango;
+using Shelly.Gtk.Services;
 using Shelly.Gtk.UiModels;
 using WrapMode = Gtk.WrapMode;
 
@@ -7,7 +8,7 @@ namespace Shelly.Gtk.Windows.Dialog;
 
 public static class PkgbuildPreview
 {
-    public static void ShowPackageBuildPreview(Overlay parentOverlay, PackageBuildEventArgs e)
+    public static void ShowPackageBuildPreview(Overlay parentOverlay, PackageBuildEventArgs e, IGenericQuestionService questionService)
     {
         var background = Box.New(Orientation.Horizontal, 0);
         background.AddCssClass("lockout-overlay");
@@ -50,6 +51,7 @@ public static class PkgbuildPreview
         {
             var clipboard = copyButton.GetClipboard();
             clipboard.SetText(e.PkgBuild);
+            questionService.RaiseToastMessage(new ToastMessageEventArgs("PKGBUILD copied to clipboard"));
         };
 
         var titleLabel = Label.New(e.Title);

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -20,7 +20,7 @@ public static class PkgbuildPreview
         var baseFrame = Frame.New(null);
         baseFrame.SetHalign(Align.Center);
         baseFrame.SetValign(Align.Center);
-        baseFrame.SetSizeRequest(800, 720); 
+        baseFrame.SetSizeRequest(900, 600); 
         baseFrame.SetMarginTop(20);
         baseFrame.SetMarginBottom(20);
         baseFrame.SetMarginStart(20);


### PR DESCRIPTION
This PR adds preview functionality to the side panel on AUR Install:

<img width="336" height="837" alt="image" src="https://github.com/user-attachments/assets/510a0e64-4b97-4862-82ac-04331907a0c8" />

Now, once this button is pressed, the PKGBUILD information will be displayed to the user:

<img width="1099" height="734" alt="image" src="https://github.com/user-attachments/assets/79ea92b4-1d01-41d3-9279-91e4c33ad558" />

The user may also copy it's contents to the clipboard.
