### PR TITLE
Fix tab padding shift when changing selection

### DIFF
--- a/Shelly.Gtk/Assets/style.css
+++ b/Shelly.Gtk/Assets/style.css
@@ -166,6 +166,12 @@ flowboxchild:hover {
     background-color: alpha( @theme_fg_color, 0.1);
 }
 
+notebook > header > tabs > tab,
+notebook > header > tabs > tab:checked {
+    padding: 6px 12px;
+    margin: 0;
+}
+
 .sidebar-nav button:checked {
     background: alpha( @theme_fg_color, 0.12);
     font-weight: bold;


### PR DESCRIPTION
- Notebook tab padding/margin was inheriting different values for the `:checked` state, causing the Install/Updates/Manage tab row to shift horizontally when the active selection changed.
- Pin both `tab` and `tab:checked` to identical `padding: 6px 12px` and `margin: 0` in `Shelly.Gtk/Assets/style.css` so tab positions stay fixed across selection changes.