### PR TITLE
Add search to package group dropdown

### DIFF
--- a/Shelly.Gtk/UiFiles/Package/PackageWindow.ui
+++ b/Shelly.Gtk/UiFiles/Package/PackageWindow.ui
@@ -23,10 +23,14 @@
                                 <property name="width-request">250</property>
                             </object>
                         </child>
-                      
                         <child>
                             <object class="GtkDropDown" id="grouping_selection">
-                                <property name="tooltip-text">Group Filter</property>
+                                <property name="tooltip-text">Package Group Filter</property>
+                                <property name="enable-search">true</property>
+                                <property name="search-match-mode">substring</property>
+                                <property name="expression">
+                                      <lookup name='string' type="GtkStringObject"></lookup>
+                                </property>
                             </object>
                         </child>
                         <child>

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -92,7 +92,6 @@ public class PackageInstall(
         _detailRevealer = (Revealer)_builder.GetObject("detail_revealer")!;
         _detailBox = (Box)_builder.GetObject("detail_box")!;
         _groupDropDown = (DropDown)_builder.GetObject("grouping_selection")!;
-        _groupDropDown.EnableSearch = false;
         _upgradeCheck = (CheckButton)_builder.GetObject("upgrade_check")!;
         _showHiddenCheck = (CheckButton)_builder.GetObject("show_hidden_check")!;
 


### PR DESCRIPTION
This adds a search feature to the package group dropdown in PackageWindow.ui.
<img width="296" height="279" alt="image" src="https://github.com/user-attachments/assets/27f3d9f1-c83a-4c12-af3b-06518288081c" />