### PR TITLE
Fix first item not selected

### DIFF
--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -98,7 +98,7 @@ public class AurInstall(
         _listStore = Gio.ListStore.New(AurPackageGObject.GetGType());
         _selectionModel = SingleSelection.New(_listStore);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = true;
+        _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
         _searchForPackageLabel = (Label)builder.GetObject("search_overlay")!;
         _searchForPackageLabel.Label_ = "<span size='large'>Search for AUR packages</span>";
@@ -375,7 +375,7 @@ public class AurInstall(
                     index++;
                 }
                 
-                if (_listStore.GetNItems() > 0 && _selectionModel.Autoselect)
+                if (_listStore.GetNItems() > 0)
                 {
                     _selectionModel.SetSelected(0);
                     var firstItem = _selectionModel.GetSelectedItem();

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -98,7 +98,7 @@ public class AurInstall(
         _listStore = Gio.ListStore.New(AurPackageGObject.GetGType());
         _selectionModel = SingleSelection.New(_listStore);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = false;
+        _selectionModel.Autoselect = true;
         _columnView.SetModel(_selectionModel);
         _searchForPackageLabel = (Label)builder.GetObject("search_overlay")!;
         _searchForPackageLabel.Label_ = "<span size='large'>Search for AUR packages</span>";
@@ -141,7 +141,7 @@ public class AurInstall(
         ColumnViewHelper.AlignColumnHeader(_columnView, 2, Align.End);
         ColumnViewHelper.AlignColumnHeader(_columnView, 3, Align.End);
         ColumnViewHelper.AlignColumnHeader(_columnView, 4, Align.End);
-
+        
         _columnView.OnActivate += (_, _) =>
         {
             var item = _selectionModel.GetSelectedItem();
@@ -374,7 +374,17 @@ public class AurInstall(
                     _listStore.Append(pkgObj);
                     index++;
                 }
-
+                
+                if (_listStore.GetNItems() > 0 && _selectionModel.Autoselect)
+                {
+                    _selectionModel.SetSelected(0);
+                    var firstItem = _selectionModel.GetSelectedItem();
+                    if (firstItem is AurPackageGObject pkgObj)
+                    {
+                        ShowPackageDetails(_aurPackages[pkgObj.Index]);
+                    }
+                }
+                
                 return false;
             });
         }

--- a/Shelly.Gtk/Windows/AUR/AurRemove.cs
+++ b/Shelly.Gtk/Windows/AUR/AurRemove.cs
@@ -78,7 +78,7 @@ public class AurRemove(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = true;
+        _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _versionColumn);
@@ -310,6 +310,17 @@ public class AurRemove(
                     _listStore.Append(pkgObj);
                     index++;
                 }
+                
+                if (_listStore.GetNItems() > 0)
+                {
+                    _selectionModel.SetSelected(0);
+                    var firstItem = _selectionModel.GetSelectedItem();
+                    if (firstItem is AurPackageGObject pkgObj)
+                    {
+                        ShowPackageDetails(_aurPackages[pkgObj.Index]);
+                    }
+                }
+
 
                 return false;
             });

--- a/Shelly.Gtk/Windows/AUR/AurUpdate.cs
+++ b/Shelly.Gtk/Windows/AUR/AurUpdate.cs
@@ -82,7 +82,7 @@ public class AurUpdate(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = true;
+        _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _versionColumn);
@@ -318,6 +318,16 @@ public class AurUpdate(
                 {
                     _packageGObjectRefs.Add(gobject);
                     _listStore.Append(gobject);
+                }
+                
+                if (_listStore.GetNItems() > 0)
+                {
+                    _selectionModel.SetSelected(0);
+                    var firstItem = _selectionModel.GetSelectedItem();
+                    if (firstItem is AurUpdateGObject pkgObj)
+                    {
+                        ShowPackageDetails(pkgObj);
+                    }
                 }
 
                 _noPackagesLabel.Visible = packages.Count == 0;

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -100,7 +100,7 @@ public class PackageInstall(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = true;
+        _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _sizeColumn, _versionColumn, _repositoryColumn);
@@ -687,6 +687,15 @@ public class PackageInstall(
                 _currentDetailPkg = null;
                 while (_detailBox.GetFirstChild() is { } child) _detailBox.Remove(child);
                 cleared.TrySetResult();
+                if (_listStore.GetNItems() > 0)
+                {
+                    _selectionModel.SetSelected(0);
+                    var firstItem = _selectionModel.GetSelectedItem();
+                    if (firstItem is AlpmPackageGObject pkgObj)
+                    {
+                        ShowPackageDetails(_packageGObjectRefs[pkgObj.Index]);
+                    }
+                }
                 return false;
             });
             await cleared.Task;

--- a/Shelly.Gtk/Windows/Packages/PackageManagement.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageManagement.cs
@@ -97,7 +97,7 @@ public class PackageManagement(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = true;
+        _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
         _groupDropDown = (DropDown)builder.GetObject("grouping_selection")!;
         _detailRevealer = (Revealer)builder.GetObject("detail_revealer")!;
@@ -725,6 +725,16 @@ public class PackageManagement(
                     _packageData.Add(package);
                     _packageGObjectRefs.Add(pkgObj);
                     _listStore.Append(pkgObj);
+                }
+                
+                if (_listStore.GetNItems() > 0)
+                {
+                    _selectionModel.SetSelected(0);
+                    var firstItem = _selectionModel.GetSelectedItem();
+                    if (firstItem is AlpmPackageGObject pkgObj)
+                    {
+                        ShowPackageDetails(_packageGObjectRefs[pkgObj.Index]);
+                    }
                 }
 
                 packages.Clear();

--- a/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
@@ -91,7 +91,7 @@ public class PackageUpdate(
         _filterListModel = FilterListModel.New(_listStore, _filter);
         _selectionModel = SingleSelection.New(_filterListModel);
         _selectionModel.CanUnselect = true;
-        _selectionModel.Autoselect = true;
+        _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
 
         SetupColumns(_checkColumn, _nameColumn, _sizeDiffColumn, _oldColumn, _versionColumn);
@@ -643,6 +643,17 @@ public class PackageUpdate(
 
                 _noPackagesLabel.Visible = packages.Count == 0;
                 _updateButton.SetSensitive(AnySelected());
+
+                if (_listStore.GetNItems() > 0)
+                {
+                    _selectionModel.SetSelected(0);
+                    var firstItem = _selectionModel.GetSelectedItem();
+                    if (firstItem is AlpmUpdateGObject pkgObj)
+                    {
+                        ShowPackageDetails(pkgObj);
+                    }
+                }
+                
                 return false;
             });
         }


### PR DESCRIPTION
This PR adjusts the selection behavior for the Package Management and AUR windows to resolve a package detail soft-lock.

Now, the first item will be selected, but the "AutoSelect" property is turned off. This is meant to fix a regression that ocurred whenever a user would attempt to select an item in the list, and that item was the only element present. If this happened, the user would be locked out of expanding the side menu to reveal more information about the package being displayed.

After this change, the first item will always be selected upon reloading a page, but "AutoSelect" won't persist, allowing users to de-select an item and display the desired information without being locked out.