### PR TITLE
Refactor `BottomBarRegion` to conditionally render bar lines with ASC…

### DIFF
--- a/Shelly-CLI/ConsoleLayouts/BottomBarRegion.cs
+++ b/Shelly-CLI/ConsoleLayouts/BottomBarRegion.cs
@@ -332,8 +332,11 @@ public sealed class BottomBarRegion : IDisposable
         DrawStickies();
         foreach (var key in _order)
         {
-            Console.Out.Write(RenderBarLine(_bars[key]));
-            Console.Out.Write("\n");
+            var line = RenderBarLine(_bars[key]);
+            if (_asciiOnly)
+                Console.Out.WriteLine(Markup.Remove(line));
+            else
+                AnsiConsole.MarkupLine(line);
             _barRowsDrawn++;
         }
 


### PR DESCRIPTION
…II fallback or ANSI markup based on `_asciiOnly`.


## Release blurb
* Fixed rendering of ascii output on shells so that it now looks like Pacman and not a giant ball of white text.