### PR TITLE
Sync .desktop file contents between files

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -106,6 +106,7 @@ Exec=/usr/bin/shelly-notifications
 Icon=shelly-tray
 Type=Application
 Categories=System;Utility;
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
 Terminal=false
 NoDisplay=true
 EOF

--- a/PKGBUILD-bin
+++ b/PKGBUILD-bin
@@ -58,6 +58,7 @@ Exec=/usr/bin/shelly-ui
 Icon=shelly
 Type=Application
 Categories=System;Utility;
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
 Terminal=false
 Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
 

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -111,6 +111,7 @@ Exec=/usr/bin/shelly-notifications
 Icon=shelly-tray
 Type=Application
 Categories=System;Utility;
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
 Terminal=false
 NoDisplay=true
 EOF

--- a/local-install.sh
+++ b/local-install.sh
@@ -132,7 +132,24 @@ Exec=/usr/bin/shelly-ui
 Icon=shelly
 Type=Application
 Categories=System;Utility;
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
 Terminal=false
+Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
+
+[Desktop Action FlatpakInstall]
+Name=Flatpak Install
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-install
+
+[Desktop Action FlatpakUpdate]
+Name=Flatpak Update
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-update
+
+[Desktop Action FlatpakRemove]
+Name=Flatpak Remove
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-remove
 EOF
 
 echo "Creating notifications entry"

--- a/local-install.sh
+++ b/local-install.sh
@@ -155,12 +155,15 @@ EOF
 echo "Creating notifications entry"
 cat <<EOF > /usr/share/applications/shelly-notifications.desktop
 [Desktop Entry]
-Name=Shelly-Notifications
+Name=Shelly Notifications
+Comment=Notification service for Shelly package manager
 Exec=/usr/bin/shelly-notifications
-Icon=shelly
+Icon=shelly-tray
 Type=Application
 Categories=System;Utility;
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
 Terminal=false
+NoDisplay=true
 EOF
 
 


### PR DESCRIPTION
My shelly-bin installation from ArchLinux AUR was lacking keywords in .desktop file, therefore probably used "PKGBUILD-bin" or "local-install.sh" for build. I wanted to synchronize the contents anyways just in case, though it does not completely resolves the issue.