### PR TITLE
Use `RunWithSynchronizationContext` for application execution

### DIFF
--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -884,7 +884,7 @@ sealed class Program
             }
         };
 
-        return application.Run(args);
+        return application.RunWithSynchronizationContext(args);
     }
 
     private static bool _fingerprintBannerShown;


### PR DESCRIPTION
My assumption is that this is needed for C# to properly unitize async/await. It functions at the moment, but threading might not be "correct"

Here is a sample using it https://github.com/gircore/gir.core/blob/main/src/Samples/Gtk-4.0/Async/Program.cs

- https://learn.microsoft.com/en-us/dotnet/api/system.threading.synchronizationcontext?view=net-10.0
- https://gircore.github.io/api/Gio.Application.html#Gio_Application_RunWithSynchronizationContext_System_String___

But it needs additional research.