### PR TITLE
Remove unnecessary `TrimExcess` and manual garbage collection calls

### DIFF
--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -288,8 +288,6 @@ sealed class Program
 
                 foreach (var w in windows)
                     w.Dispose();
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
             }
 
             void LoadPackagesPage()

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -705,9 +705,7 @@ public sealed class PackageInstall(
                 }
 
                 _packageGObjectRefs.Clear();
-                _packageGObjectRefs.TrimExcess();
                 _packageData.Clear();
-                _packageData.TrimExcess();
                 while (_detailBox.GetFirstChild() is { } child) _detailBox.Remove(child);
                 cleared.TrySetResult();
                 if (_listStore.GetNItems() > 0)
@@ -723,9 +721,6 @@ public sealed class PackageInstall(
                 return false;
             });
             await cleared.Task;
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
 
             ct.ThrowIfCancellationRequested();
 
@@ -737,7 +732,6 @@ public sealed class PackageInstall(
             var installedPackages = await privilegedOperationService.GetInstalledPackagesAsync();
             _installedPackageNames = new HashSet<string>(installedPackages.Select(x => x.Name));
             installedPackages.Clear();
-            installedPackages.TrimExcess();
             var index = 0;
 
             GLib.Functions.IdleAdd(0, () =>
@@ -749,7 +743,6 @@ public sealed class PackageInstall(
                         OverlayHelper.HideLoading(_loadingOverlay, _loadingSpinner);
                     }
                     packages.Clear();
-                    packages.TrimExcess();
                     return false;
                 }
 
@@ -783,7 +776,6 @@ public sealed class PackageInstall(
                 if (index < packages.Count) return true;
                 var count = packages.Count;
                 packages.Clear();
-                packages.TrimExcess();
 
                 if (_loadGeneration == generation)
                 {


### PR DESCRIPTION
Need to investigate current memory usage and see how GC impacts/improves it. How the reference count happens and if there are any dangling references left that need to be disposed.
