### PR TITLE
Parse arch news from html to markdown

### DIFF
--- a/Shelly-CLI/Commands/DefaultCommand.cs
+++ b/Shelly-CLI/Commands/DefaultCommand.cs
@@ -1,50 +1,40 @@
-using System.ComponentModel.Design;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using PackageManager.Alpm;
 using PackageManager.Aur;
 using PackageManager.Aur.Models;
-using PackageManager.Utilities;
 using Shelly_CLI.Commands.Aur;
 using Shelly_CLI.Commands.Flatpak;
 using Shelly_CLI.Commands.Standard;
-using Shelly_CLI.Configuration;
 using Shelly.Utilities;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using static Shelly_CLI.Configuration.DefaultCommand;
 
 namespace Shelly_CLI.Commands;
 
 internal sealed record PackageChoice(string Name, string Version, string Repo, bool IsExit = false)
 {
-    public static PackageChoice Exit { get; } = new("", "", "", IsExit: true);
+    public static PackageChoice Exit { get; } = new("", "", "", true);
 }
 
 public class DefaultCommand : AsyncCommand<DefaultCommandSettings>
 {
-    //No Confirm is not implemented for default command by design
-    public override async Task<int> ExecuteAsync(CommandContext context, [NotNull] DefaultCommandSettings settings)
+    // No Confirm is not implemented for default command by design
+    public override async Task<int> ExecuteAsync(CommandContext context, DefaultCommandSettings settings)
     {
-        
         if (settings.Version)
         {
             new VersionCommand().Execute(context);
             return 0;
         }
-        
+
         var configPath = XdgPaths.ShellyConfig("config.json");
-        if (!File.Exists(configPath))
-        {
-            return 1;
-        }
+        if (!File.Exists(configPath)) return 1;
 
         var json = await File.ReadAllTextAsync(configPath);
 
         var config = JsonSerializer.Deserialize<ShellyConfig>(json, ShellyCLIJsonContext.Default.ShellyConfig);
-        if (config == null)
-        {
-            return 1;
-        }
+        if (config == null) return 1;
 
         if (!string.IsNullOrEmpty(settings.SearchString))
         {
@@ -65,51 +55,37 @@ public class DefaultCommand : AsyncCommand<DefaultCommandSettings>
                         ? "[yellow]Exit[/]"
                         : $"{choice.Name} : {choice.Version} : {choice.Repo}"));
 
-            if (selection.IsExit)
-            {
-                return 0;
-            }
+            if (selection.IsExit) return 0;
 
             if (selection.Repo == "AUR")
-            {
-                await new Aur.AurInstallCommand().ExecuteAsync(context, new AurInstallSettings()
+                await new AurInstallCommand().ExecuteAsync(context, new AurInstallSettings
                 {
                     Packages = [selection.Name]
                 });
-            }
             else
-            {
-                await new InstallCommand().ExecuteAsync(context, new InstallPackageSettings()
+                await new InstallCommand().ExecuteAsync(context, new InstallPackageSettings
                 {
                     Packages = [selection.Name]
                 });
-            }
-            
+
             return 0;
         }
 
-        var parsed =
-            (Shelly_CLI.Configuration.DefaultCommand)Enum.Parse(typeof(Shelly_CLI.Configuration.DefaultCommand),
-                config.DefaultExecution);
-        return parsed switch
+        var command = Enum.Parse<Configuration.DefaultCommand>(config.DefaultExecution);
+        return command switch
         {
-            Shelly_CLI.Configuration.DefaultCommand.UpgradeStandard => await new UpgradeCommand().ExecuteAsync(context,
-                new UpgradeSettings()),
-            Shelly_CLI.Configuration.DefaultCommand.UpgradeFlatpak => new FlatpakUpgrade().Execute(context),
-            Shelly_CLI.Configuration.DefaultCommand.UpgradeAur => await new AurUpgradeCommand().ExecuteAsync(context,
-                new AurUpgradeSettings()),
-            Shelly_CLI.Configuration.DefaultCommand.UpgradeAll => await new UpgradeCommand().ExecuteAsync(context,
-                new UpgradeSettings { All = true }),
-            Shelly_CLI.Configuration.DefaultCommand.Sync => new SyncCommand().Execute(context, new SyncSettings()),
-            Shelly_CLI.Configuration.DefaultCommand.SyncForce => new SyncCommand().Execute(context,
-                new SyncSettings { Force = true }),
-            Shelly_CLI.Configuration.DefaultCommand.ListInstalled => new ListInstalledCommand().Execute(context,
-                new AlpmListSettings()),
+            UpgradeStandard => await new UpgradeCommand().ExecuteAsync(context, new UpgradeSettings()),
+            UpgradeFlatpak => new FlatpakUpgrade().Execute(context),
+            UpgradeAur => await new AurUpgradeCommand().ExecuteAsync(context, new AurUpgradeSettings()),
+            UpgradeAll => await new UpgradeCommand().ExecuteAsync(context, new UpgradeSettings { All = true }),
+            Sync => new SyncCommand().Execute(context, new SyncSettings()),
+            SyncForce => new SyncCommand().Execute(context, new SyncSettings { Force = true }),
+            ListInstalled => new ListInstalledCommand().Execute(context, new AlpmListSettings()),
             _ => 1
         };
     }
 
-    private List<AlpmPackageDto> SearchStandard(string filter)
+    private static List<AlpmPackageDto> SearchStandard(string filter)
     {
         var manager = new AlpmManager();
         manager.Initialize();
@@ -124,7 +100,7 @@ public class DefaultCommand : AsyncCommand<DefaultCommandSettings>
         return packages;
     }
 
-    private async Task<List<AurPackageDto>> SearchAur(string filter)
+    private static async Task<List<AurPackageDto>> SearchAur(string filter)
     {
         var manager = new AurPackageManager();
         await manager.Initialize();

--- a/Shelly-CLI/Commands/Standard/ArchNews.cs
+++ b/Shelly-CLI/Commands/Standard/ArchNews.cs
@@ -52,7 +52,7 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
             var cachedFeed = await LoadCachedFeed();
             var feed = await GetRssFeedAsync(ArchlinuxFeed);
 
-            var newFeed = feed.Except(cachedFeed).ToList();
+            var newFeed = feed.ExceptBy(cachedFeed.Select(model => model.Link), model => model.Link).ToList();
 
             if (settings.Json)
             {

--- a/Shelly-CLI/Commands/Standard/ArchNews.cs
+++ b/Shelly-CLI/Commands/Standard/ArchNews.cs
@@ -1,9 +1,10 @@
+using System.Net;
+using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using PackageManager.Utilities;
 using PackageManager.Wire;
 using Shelly_CLI.Commands.Standard.Models;
+using Shelly_CLI.Utility;
 using Shelly.Utilities;
 using Shelly.Utilities.Eventing;
 using Spectre.Console;
@@ -26,11 +27,8 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
             {
                 var feed = await GetRssFeedAsync(ArchlinuxFeed);
                 if (settings.Json)
-                {
                     await OutputFeed(feed);
-                }
                 else
-                {
                     foreach (var item in feed)
                     {
                         AnsiConsole.MarkupLine($"[yellow]\n{item.Title.EscapeMarkup()}[/]");
@@ -38,9 +36,8 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
                         AnsiConsole.MarkupLine($"[blue]{item.Link.EscapeMarkup()}[/]");
                         AnsiConsole.MarkupLine($"[white]{item.Description.EscapeMarkup()}[/]");
                     }
-                }
 
-                CacheFeed(feed);
+                await CacheFeed(feed);
             }
             catch (Exception e)
             {
@@ -52,7 +49,7 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
         }
         else
         {
-            var cachedFeed = LoadCachedFeed();
+            var cachedFeed = await LoadCachedFeed();
             var feed = await GetRssFeedAsync(ArchlinuxFeed);
 
             var newFeed = feed.Except(cachedFeed).ToList();
@@ -60,7 +57,7 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
             if (settings.Json)
             {
                 await OutputFeed(newFeed);
-                if (newFeed.Count > 0) CacheFeed(feed);
+                if (newFeed.Count > 0) await CacheFeed(feed);
                 return 0;
             }
 
@@ -72,29 +69,29 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
                 AnsiConsole.MarkupLine($"[white]{item.Description.EscapeMarkup()}[/]");
             }
 
-            if (newFeed.Count > 0) CacheFeed(feed);
+            if (newFeed.Count > 0) await CacheFeed(feed);
             else AnsiConsole.MarkupLine("[green]No new news found[/]");
         }
 
         return 0;
     }
 
-    private static void CacheFeed(List<RssModel> feed)
+    private static async Task CacheFeed(List<RssModel> feed)
     {
         XdgPaths.EnsureDirectory(FeedFolder);
 
         var json = JsonSerializer.Serialize(feed, ShellyCLIJsonContext.Default.ListRssModel);
-        File.WriteAllText(FeedPath, json);
+        await File.WriteAllTextAsync(FeedPath, json);
         XdgPaths.FixOwnershipIfRoot(FeedPath);
     }
 
-    private static List<RssModel> LoadCachedFeed()
+    private static async Task<List<RssModel>> LoadCachedFeed()
     {
-        if (!File.Exists(FeedPath)) return [];
+        if (File.Exists(FeedPath)) return [];
 
         try
         {
-            var json = File.ReadAllText(FeedPath);
+            var json = await File.ReadAllTextAsync(FeedPath);
             return JsonSerializer.Deserialize(json, ShellyCLIJsonContext.Default.ListRssModel) ?? [];
         }
         catch
@@ -105,15 +102,15 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
 
     private static async Task<List<RssModel>> GetRssFeedAsync(string url)
     {
-        using var client = new HttpClient();
-        var xmlString = await client.GetStringAsync(url);
+        var xmlString = await CreateHttpClient().GetStringAsync(url);
 
         var xml = XDocument.Parse(xmlString);
 
         return xml.Descendants("item").Select(item => new RssModel
         {
-            Title = item.Element("title")?.Value ?? "", Link = item.Element("link")?.Value ?? "",
-            Description = Regex.Replace(item.Element("description")?.Value ?? "", "<.*?>", string.Empty),
+            Title = item.Element("title")?.Value ?? "",
+            Link = item.Element("link")?.Value ?? "",
+            Description = HtmlToMarkdown.Convert(item.Element("description")?.Value ?? ""),
             PubDate = item.Element("pubDate")?.Value ?? ""
         }).Reverse().ToList();
     }
@@ -128,9 +125,28 @@ public class ArchNews : AsyncCommand<ArchNewsSettings>
         {
             var json = JsonSerializer.Serialize(feed, ShellyCLIJsonContext.Default.ListRssModel);
             await using var stdout = Console.OpenStandardOutput();
-            await using var writer = new StreamWriter(stdout, System.Text.Encoding.UTF8);
+            await using var writer = new StreamWriter(stdout, Encoding.UTF8);
             await writer.WriteLineAsync(json);
             await writer.FlushAsync();
         }
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        return new HttpClient(new SocketsHttpHandler
+        {
+            AutomaticDecompression = DecompressionMethods.All,
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 10,
+            ConnectTimeout = TimeSpan.FromSeconds(30),
+            EnableMultipleHttp2Connections = true,
+            EnableMultipleHttp3Connections = true
+        })
+        {
+            Timeout = TimeSpan.FromMinutes(1),
+            DefaultRequestHeaders = { UserAgent = { Http.UserAgent } },
+            DefaultRequestVersion = HttpVersion.Version11,
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+        };
     }
 }

--- a/Shelly-CLI/Commands/Standard/Models/RssModel.cs
+++ b/Shelly-CLI/Commands/Standard/Models/RssModel.cs
@@ -1,7 +1,7 @@
 
 namespace Shelly_CLI.Commands.Standard.Models;
 
-public partial record RssModel
+public record RssModel
 {
     public string? Title { get; init; }
     public string? Link { get; init; }

--- a/Shelly-CLI/Utility/HtmlToMarkdown.cs
+++ b/Shelly-CLI/Utility/HtmlToMarkdown.cs
@@ -1,0 +1,242 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace Shelly_CLI.Utility;
+
+internal static partial class HtmlToMarkdown
+{
+    public static string Convert(string html)
+    {
+        return new Converter().ConvertInternal(html);
+    }
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex SpaceRegex();
+
+    private sealed class Converter
+    {
+        private readonly List<(string Id, string Url)> _references = [];
+        private int _refCounter;
+
+        public string ConvertInternal(string html)
+        {
+            var xml = $"<root>{html}</root>";
+            var settings = new XmlReaderSettings
+            {
+                IgnoreWhitespace = false,
+                DtdProcessing = DtdProcessing.Prohibit
+            };
+
+            var sb = new StringBuilder();
+
+            using var reader = XmlReader.Create(new StringReader(xml), settings);
+            ReadDocument(reader, sb);
+
+            AppendReferences(sb);
+            return sb.ToString().TrimEnd();
+        }
+
+        private void ReadDocument(XmlReader reader, StringBuilder sb)
+        {
+            while (reader.Read())
+                switch (reader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        if (reader.LocalName != "root")
+                            AppendBlock(sb, ReadBlock(reader));
+                        break;
+
+                    case XmlNodeType.Text:
+                    case XmlNodeType.CDATA:
+                        sb.Append(reader.Value);
+                        break;
+                }
+        }
+
+        private string ReadBlock(XmlReader reader)
+        {
+            return reader.LocalName switch
+            {
+                "p" => ReadInlineContent(reader, "p"),
+                "ul" => ReadList(reader, "ul", false),
+                "ol" => ReadList(reader, "ol", true),
+                "blockquote" => ReadBlockquote(reader),
+                "h1" or "h2" or "h3" or "h4" or "h5" or "h6" => ReadHeading(reader),
+                "a" => ReadAnchor(reader),
+                "strong" or "b" => $"**{ReadInlineContent(reader, reader.LocalName)}**",
+                "em" or "i" => $"*{ReadInlineContent(reader, reader.LocalName)}*",
+                "code" => $"`{ReadInlineContent(reader, reader.LocalName)}`",
+                _ => ReadInlineContent(reader, reader.LocalName)
+            };
+        }
+
+        private static void AppendBlock(StringBuilder sb, string content)
+        {
+            if (string.IsNullOrEmpty(content))
+                return;
+
+            if (sb.Length > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine();
+            }
+
+            sb.Append(content);
+        }
+
+        private string ReadInlineContent(XmlReader reader, string elementName)
+        {
+            var sb = new StringBuilder();
+
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == elementName)
+                    break;
+
+                switch (reader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        sb.Append(ReadInlineElement(reader));
+                        break;
+
+                    case XmlNodeType.Text:
+                    case XmlNodeType.CDATA:
+                        sb.Append(NormalizeWhitespace(reader.Value));
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private string ReadInlineElement(XmlReader reader)
+        {
+            return reader.LocalName switch
+            {
+                "strong" or "b" => $"**{ReadInlineContent(reader, reader.LocalName)}**",
+                "em" or "i" => $"*{ReadInlineContent(reader, reader.LocalName)}*",
+                "code" => $"`{ReadInlineContent(reader, reader.LocalName)}`",
+                "a" => ReadAnchor(reader),
+                _ => ReadInlineContent(reader, reader.LocalName)
+            };
+        }
+
+        private string ReadAnchor(XmlReader reader)
+        {
+            var href = reader.GetAttribute("href");
+            var text = ReadInlineContent(reader, "a");
+
+            if (string.IsNullOrWhiteSpace(href))
+                return text;
+
+            var refId = (++_refCounter).ToString();
+            _references.Add((refId, href));
+            return $"[{text}][{refId}]";
+        }
+
+        private string ReadList(XmlReader reader, string listElement, bool ordered)
+        {
+            var sb = new StringBuilder();
+            var index = 1;
+
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == listElement)
+                    break;
+
+                if (reader is not { NodeType: XmlNodeType.Element, LocalName: "li" })
+                    continue;
+
+                var prefix = ordered ? $"{index}. " : "- ";
+                var content = ReadInlineContent(reader, "li").Trim();
+                AppendListItem(sb, prefix, content);
+
+                if (ordered)
+                    index++;
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private static void AppendListItem(StringBuilder sb, string prefix, string content)
+        {
+            var lines = content.Split('\n');
+
+            for (var i = 0; i < lines.Length; i++)
+                if (i == 0)
+                    sb.AppendLine($"{prefix}{lines[i]}");
+                else
+                    sb.AppendLine($"  {lines[i]}");
+        }
+
+        private string ReadBlockquote(XmlReader reader)
+        {
+            var sb = new StringBuilder();
+
+            while (reader.Read())
+            {
+                if (reader is { NodeType: XmlNodeType.EndElement, LocalName: "blockquote" })
+                    break;
+
+                switch (reader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        AppendBlock(sb, ReadBlock(reader));
+                        break;
+
+                    case XmlNodeType.Text:
+                    case XmlNodeType.CDATA:
+                        sb.Append(NormalizeWhitespace(reader.Value));
+                        break;
+                }
+            }
+
+            return PrefixBlockquote(sb.ToString().TrimEnd());
+        }
+
+        private string ReadHeading(XmlReader reader)
+        {
+            var level = reader.LocalName[1] - '0';
+            var hashes = new string('#', level);
+            var content = ReadInlineContent(reader, reader.LocalName).Trim();
+            return $"{hashes} {content}";
+        }
+
+        private void AppendReferences(StringBuilder sb)
+        {
+            if (_references.Count == 0)
+                return;
+
+            sb.AppendLine();
+            sb.AppendLine();
+
+            foreach (var (id, url) in _references)
+                sb.AppendLine($"[{id}]: {url}");
+        }
+
+        private static string PrefixBlockquote(string content)
+        {
+            var lines = content.Split('\n');
+            var sb = new StringBuilder();
+
+            foreach (var raw in lines)
+            {
+                var line = raw.TrimEnd('\r');
+                sb.Append("> ");
+
+                if (!string.IsNullOrWhiteSpace(line))
+                    sb.Append(line);
+
+                sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private static string NormalizeWhitespace(string value)
+        {
+            return SpaceRegex().Replace(value, " ");
+        }
+    }
+}


### PR DESCRIPTION
Reason: at the moment some links can get lost and spacing is inconsistent with current simple parsing implementation. This should unify the output by converting from html to markdown.

For UI additional work would be needed to convert from markdown to [pango compatible markup](https://docs.gtk.org/Pango/pango_markup.html).