### PR TITLE
Create update-pot.sh and commit a new POT file

### DIFF
--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -809,7 +809,7 @@ sealed class Program
                     if (packagesNeedingUpdate.Aur.Count == 0 && packagesNeedingUpdate.Packages.Count == 0 &&
                         packagesNeedingUpdate.Flatpaks.Count == 0)
                     {
-                        var toastArgs = new ToastMessageEventArgs("No packages need to be upgraded");
+                        var toastArgs = new ToastMessageEventArgs(T("No packages need to be upgraded"));
                         genericQuestionService.RaiseToastMessage(toastArgs);
                         return;
                     }
@@ -817,7 +817,7 @@ sealed class Program
                     if (!configService.LoadConfig().NoConfirm)
                     {
                         var confirmArgs = new GenericQuestionEventArgs(
-                            "Upgrade All Packages?",
+                            T("Upgrade All Packages?"),
                             BottomBarExtensions.BuildUpgradeConfirmationMessage(packagesNeedingUpdate),
                             true
                         );

--- a/Shelly.Gtk/po/shelly-ui.pot
+++ b/Shelly.Gtk/po/shelly-ui.pot
@@ -1265,7 +1265,8 @@ msgstr ""
 msgid "Remove Optional Deps"
 msgstr ""
 
-msgid "Also remove orphaned optional dependencies installed with these packages."
+msgid ""
+"Also remove orphaned optional dependencies installed with these packages."
 msgstr ""
 
 msgid "Add Tray To Auto Start"
@@ -1314,4 +1315,73 @@ msgid "Downgrade"
 msgstr ""
 
 msgid "Enable Package Downgrade"
+msgstr ""
+
+msgid "No packages need to be upgraded"
+msgstr ""
+
+msgid "Upgrade All Packages?"
+msgstr ""
+
+msgid "Happy pride month!"
+msgstr ""
+
+msgid "You found Chel's hidden page."
+msgstr ""
+
+msgid "Show Recommended"
+msgstr ""
+
+msgid "Show Packages"
+msgstr ""
+
+msgid "Show AUR"
+msgstr ""
+
+msgid "Show Flat"
+msgstr ""
+
+msgid "Show AppImage"
+msgstr ""
+
+msgid "Show Shelly Searchs"
+msgstr ""
+
+msgid ""
+"Access the Arch User Repository for a vast collection of community-"
+"maintained packages. AUR packages can contain malicous software, so please "
+"use caution when using the AUR."
+msgstr ""
+
+msgid "installed"
+msgstr ""
+
+msgid "already installed"
+msgstr ""
+
+msgid "Repaired Flatpak installation"
+msgstr ""
+
+msgid "Failed to repair Flatpak installation"
+msgstr ""
+
+msgid "Installed Size"
+msgstr ""
+
+msgid "Build Date"
+msgstr ""
+
+msgid "Required By"
+msgstr ""
+
+msgid "Failed to load packages."
+msgstr ""
+
+msgid "Install As"
+msgstr ""
+
+msgid "Additional Options"
+msgstr ""
+
+msgid "Had an issue loading your packages. Check if you have a db lock."
 msgstr ""

--- a/Shelly.Gtk/po/update-pot.sh
+++ b/Shelly.Gtk/po/update-pot.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+package_name="shelly-ui"
+package_version=$(grep -Po '(?<=<Version>)[^<]+' ../Shelly.Gtk.csproj)
+
+xgettext --package-name="$package_name" \
+            --package-version="$package_version" \
+            --from-code=UTF-8 \
+            --keyword=T \
+            --no-location \
+            --output="$package_name"_new.pot \
+            ../*.cs \
+            ../*/{*.cs,*.ui} \
+            ../*/*/{*.cs,*.ui}
+
+msgcat --no-location \
+        --use-first \
+        "$package_name".pot \
+        "$package_name"_new.pot \
+        -o "$package_name"_tmp.pot
+
+mv "$package_name"_tmp.pot shelly-ui.pot
+rm "$package_name"_new.pot


### PR DESCRIPTION
This will generate the smallest diffs.
I think the current shelly-ui.pot is edited manually,
so there are some obsolete messages.
I recommend to use the POT file straightly:

```
xgettext --package-name="shelly-ui" \
            --package-version="2.2.4.1" \
            --from-code=UTF-8 \
            --keyword=T \
            --output="shelly-ui.pot" \
            ../*.cs \
            ../*/{*.cs,*.ui} \
            ../*/*/{*.cs,*.ui}
```