### PR TITLE
fix: schedule Recommend UI updates on GTK main thread to fix Wayland crash

### DIFF
--- a/Shelly.Gtk/Windows/Recommend.cs
+++ b/Shelly.Gtk/Windows/Recommend.cs
@@ -115,19 +115,13 @@ public sealed class Recommend(
 
             var result = JsonSerializer.Deserialize(values, RecommendJsonContext.Default.ListRecommendModel) ?? [];
 
-            if (result.Count < 1)
-            {
-                _noResultsOverlay?.SetVisible(true);
-                return;
-            }
-
-            _noResultsOverlay?.SetVisible(false);
-            _packages.Clear();
+            // Build package list on background thread (no GTK calls)
+            var packages = new List<FlatRecommendModel>();
             foreach (var item in result)
             {
                 if (!Enum.TryParse<RecommendCategory>(item.Name, out var category)) continue;
                 foreach (var pkgName in item.Packages.Where(pkgName => alpmPackages.Any(x => x.Name == pkgName)))
-                    _packages.Add(new FlatRecommendModel
+                    packages.Add(new FlatRecommendModel
                     {
                         Category = category,
                         Package = pkgName,
@@ -138,7 +132,23 @@ public sealed class Recommend(
                     });
             }
 
-            await FlowChartBuilder();
+            // All GTK widget operations must run on the main thread via IdleAdd
+            Functions.IdleAdd(0, () =>
+            {
+                if (ct.IsCancellationRequested) return false;
+
+                if (packages.Count < 1)
+                {
+                    _noResultsOverlay?.SetVisible(true);
+                    return false;
+                }
+
+                _noResultsOverlay?.SetVisible(false);
+                _packages.Clear();
+                _packages.AddRange(packages);
+                FlowChartBuilder();
+                return false;
+            });
         }
         catch (Exception e)
         {
@@ -177,7 +187,6 @@ public sealed class Recommend(
                 flox.SetSelectionMode(SelectionMode.None);
                 flox.SetColumnSpacing(8);
                 flox.SetRowSpacing(8);
-                flox.Homogeneous = true;
                 flox.MinChildrenPerLine = 1;
                 flox.MaxChildrenPerLine = 6;
 


### PR DESCRIPTION
## Problem

Clicking the Recommended tab (heart icon) crashes the app immediately on Wayland (SIGSEGV). Works fine on X11/XWayland. Reported in #970.

Two bugs in `Recommend.cs`:

**1. GTK widget calls on background thread**

`LoadDataAsync` is an `async` method — after `await` operations it resumes on a thread pool thread (no GTK SynchronizationContext). The original code called `_noResultsOverlay?.SetVisible()` and `FlowChartBuilder()` directly from that background thread, which touches GTK widgets off the main thread. On Wayland, GTK4 crashes; on X11 it happened to work.

Journal output before crash:
```
gdk-frame-clock: layout continuously requested, giving up after 4 tries
Trying to snapshot GtkFrame 0x... without a current allocation   (×30+)
Trying to snapshot GtkFlowBox 0x... without a current allocation
segfault at 0 ... in libgtk-4.so.1
```

**2. `FlowBox.Homogeneous = true` + wrapping labels = layout loop**

`Homogeneous = true` forces GTK to measure all children to find the max size. Each child contains a `Label` with `SetWrap(true)` + `MaxWidthChars = 40`. Label wrap depends on available width → available width depends on column count → column count depends on item size → item size depends on label wrap. Infinite loop, GTK4 gives up after 4 tries.

## Fix

- Build the `List<FlatRecommendModel>` on the background thread (pure data, no GTK calls)
- Schedule all GTK widget operations (`SetVisible`, `_packages.Clear/AddRange`, `FlowChartBuilder`) via `Functions.IdleAdd` so they run on the GTK main thread
- The existing `finally` block's `IdleAdd` (hide spinner) is scheduled after the UI `IdleAdd`, so GLib's FIFO queue ensures the spinner hides only after the UI is built
- Remove `flox.Homogeneous = true` to eliminate the layout feedback loop

## Testing

Tested on:
- KDE Plasma 6, Wayland, GTK4 4.22.4, CachyOS Linux (Arch-based)
- Recommended tab opens without crash on native Wayland (no `GDK_BACKEND=x11` workaround needed)

Closes #970