### PR TITLE
make padding + width same for all search objects

### DIFF
--- a/Shelly.Gtk/UiFiles/AUR/AurWindow.ui
+++ b/Shelly.Gtk/UiFiles/AUR/AurWindow.ui
@@ -16,7 +16,7 @@
                         <child>
                             <object class="GtkSearchEntry" id="search_entry">
                                 <property name="placeholder-text" translatable="yes">Search packages...</property>
-                                <property name="width-request">200</property>
+                                <property name="width-request">250</property>
                                 <style>
                                     <class name="spaced-search"/>
                                 </style>

--- a/Shelly.Gtk/UiFiles/AUR/RemoveAurWindow.ui
+++ b/Shelly.Gtk/UiFiles/AUR/RemoveAurWindow.ui
@@ -15,7 +15,7 @@
                 <child>
                     <object class="GtkSearchEntry" id="search_entry">
                         <property name="placeholder-text" translatable="yes">Search packages...</property>
-                        <property name="width-request">200</property>
+                        <property name="width-request">250</property>
                         <style>
                             <class name="spaced-search"/>
                         </style>

--- a/Shelly.Gtk/UiFiles/AUR/UpdateAurWindow.ui
+++ b/Shelly.Gtk/UiFiles/AUR/UpdateAurWindow.ui
@@ -14,7 +14,7 @@
                 <child>
                     <object class="GtkSearchEntry" id="search_entry">
                         <property name="placeholder-text" translatable="yes">Search packages...</property>
-                        <property name="width-request">200</property>
+                        <property name="width-request">250</property>
                         <style>
                             <class name="spaced-search"/>
                         </style>

--- a/Shelly.Gtk/UiFiles/AppImage.ui
+++ b/Shelly.Gtk/UiFiles/AppImage.ui
@@ -20,8 +20,11 @@
                                 <child>
                                     <object class="GtkSearchEntry" id="AppImageSearchEntry">
                                         <property name="placeholder-text" translatable="yes">Search...</property>
-                                        <property name="width-request">200</property>
+                                        <property name="width-request">250</property>
                                         <property name="valign">center</property>
+                                        <style>
+                                            <class name="spaced-search"/>
+                                        </style>
                                     </object>
                                 </child>
                                 <child>

--- a/Shelly.Gtk/UiFiles/Package/PackageManagement.ui
+++ b/Shelly.Gtk/UiFiles/Package/PackageManagement.ui
@@ -16,7 +16,10 @@
                         <child>
                             <object class="GtkSearchEntry" id="search_entry">
                                         <property name="placeholder-text" translatable="yes">Search packages...</property>
-                                <property name="width-request">200</property>
+                                <property name="width-request">250</property>
+                                <style>
+                                    <class name="spaced-search"/>
+                                </style>
                             </object>
                         </child>
                         <child>

--- a/Shelly.Gtk/UiFiles/Package/PackageWindow.ui
+++ b/Shelly.Gtk/UiFiles/Package/PackageWindow.ui
@@ -21,6 +21,9 @@
                             <object class="GtkSearchEntry" id="search_entry">
                                 <property name="placeholder-text" translatable="yes">Search packages...</property>
                                 <property name="width-request">250</property>
+                                <style>
+                                    <class name="spaced-search"/>
+                                </style>
                             </object>
                         </child>
                         <child>

--- a/Shelly.Gtk/UiFiles/Package/UpdateWindow.ui
+++ b/Shelly.Gtk/UiFiles/Package/UpdateWindow.ui
@@ -16,7 +16,10 @@
                         <child>
                             <object class="GtkSearchEntry" id="search_entry">
                                 <property name="placeholder-text" translatable="yes">Search packages...</property>
-                                <property name="width-request">200</property>
+                                <property name="width-request">250</property>
+                                <style>
+                                    <class name="spaced-search"/>
+                                </style>
                             </object>
                         </child>
                         <child>


### PR DESCRIPTION
make all search objects consistent for width and leading padding

disclaimer: not tested this end, I don't have dotnet installed. But trivial changes so should be OK??