### PR TITLE
Read and add hook dirs from pacman.conf to libalpm

### DIFF
--- a/PackageManager/Alpm/AlpmManager.cs
+++ b/PackageManager/Alpm/AlpmManager.cs
@@ -150,6 +150,11 @@ public class AlpmManager(string configPath = "/etc/pacman.conf") : IDisposable, 
             AddIgnorePkg(_handle, ignorePkg);
         }
 
+        foreach (var hookDir in _config.HookDir)
+        {
+            AddHookDir(_handle, hookDir);
+        }
+
         if (!string.IsNullOrEmpty(_config.GpgDir) && root)
         {
             SetGpgDir(_handle, _config.GpgDir);

--- a/PackageManager/Utilities/PacmanConf.cs
+++ b/PackageManager/Utilities/PacmanConf.cs
@@ -10,7 +10,7 @@ internal record PacmanConf
     public string CacheDir { get; set; } = "/var/cache/pacman/pkg";
     public string LogFile { get; set; } = "/var/log/pacman.log";
     public string GpgDir { get; set; } = "/etc/pacman.d/gnupg";
-    public string HookDir { get; set; } = "/etc/pacman.d/hooks";
+    public List<string> HookDir { get; set; } = ["/etc/pacman.d/hooks"];
     public List<string> HoldPkg { get; set; } = ["pacman", "glibc"];
     public string TransferCommand { get; set; } = "/usr/bin/curl -L -C - -f -o %o %u";
     public string TransferCommandTwo { get; set; } = "/usr/bin/wget --passive-ftp -c -O %o %u";

--- a/PackageManager/Utilities/PacmanConfParser.cs
+++ b/PackageManager/Utilities/PacmanConfParser.cs
@@ -82,7 +82,7 @@ internal static class PacmanConfParser
             case "cachedir": conf.CacheDir = value; break;
             case "logfile": conf.LogFile = value; break;
             case "gpgdir": conf.GpgDir = value; break;
-            case "hookdir": conf.HookDir = value; break;
+            case "hookdir": conf.HookDir = value.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList(); break;
             case "holdpkg": conf.HoldPkg = value.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList(); break;
             case "xfercommand":
                 if (string.IsNullOrEmpty(conf.TransferCommand)) conf.TransferCommand = value;


### PR DESCRIPTION
This allows libalpm to run hooks in /etc/pacman.d/hooks/.

When HookDir is blank in pacman.conf, pacman defaults it to the single directory /etc/pacman.d/hooks/.

This change reads all hook dirs from pacman.conf and adds them to libalpm.