### PR TITLE
Add new version collumn to AUR update

### DIFF
--- a/Shelly.Gtk/UiFiles/AUR/UpdateAurWindow.ui
+++ b/Shelly.Gtk/UiFiles/AUR/UpdateAurWindow.ui
@@ -77,12 +77,15 @@
                                             </object>
                                         </child>
                                         <child>
-                                            <object class="GtkColumnViewColumn" id="version_column">
-                                                <property name="title" translatable="yes">Version</property>
-                                                <property name="expand">true</property>
+                                            <object class="GtkColumnViewColumn" id="old_column">
+                                                <property name="title" translatable="yes">Old Version</property>
                                             </object>
                                         </child>
-                                       
+                                        <child>
+                                            <object class="GtkColumnViewColumn" id="version_column">
+                                                <property name="title" translatable="yes">Version</property>
+                                            </object>
+                                        </child>
                                     </object>
                                 </child>
                             </object>

--- a/Shelly.Gtk/Windows/AUR/AurUpdate.cs
+++ b/Shelly.Gtk/Windows/AUR/AurUpdate.cs
@@ -33,6 +33,7 @@ public class AurUpdate(
     private CustomFilter _filter = null!;
     private SignalListItemFactory _checkFactory = null!;
     private SignalListItemFactory _nameFactory = null!;
+    private SignalListItemFactory _oldVersionFactory = null!;
     private SignalListItemFactory _versionFactory = null!;
     private ColumnViewSorter _columnViewSorter = null!;
     private Box _detailBox = null!;
@@ -45,6 +46,7 @@ public class AurUpdate(
     private readonly List<AurUpdateGObject> _packageGObjectRefs = [];
     private ColumnViewColumn _checkColumn = null!;
     private ColumnViewColumn _nameColumn = null!;
+    private ColumnViewColumn _oldColumn = null!;
     private ColumnViewColumn _versionColumn = null!;
     private Button _updateButton = null!;
     private Label _noPackagesLabel = null!;
@@ -65,6 +67,9 @@ public class AurUpdate(
 
         _nameColumn = (ColumnViewColumn)builder.GetObject("name_column")!;
         _nameColumn.Resizable = true;
+
+        _oldColumn = (ColumnViewColumn)builder.GetObject("old_column")!;
+        _oldColumn.Resizable = true;
 
         _versionColumn = (ColumnViewColumn)builder.GetObject("version_column")!;
         _versionColumn.Resizable = true;
@@ -91,7 +96,7 @@ public class AurUpdate(
         _selectionModel.Autoselect = false;
         _columnView.SetModel(_selectionModel);
 
-        SetupColumns(_checkColumn, _nameColumn, _versionColumn);
+        SetupColumns(_checkColumn, _nameColumn, _oldColumn, _versionColumn);
 
         // Creating sorter
         _nameColumn.Sorter = CustomSorter.New<AurPackageGObject>((a, b) => 0);
@@ -140,6 +145,7 @@ public class AurUpdate(
 
         ColumnViewHelper.AlignColumnHeader(_columnView, 1, Align.Start);
         ColumnViewHelper.AlignColumnHeader(_columnView, 2, Align.End);
+        ColumnViewHelper.AlignColumnHeader(_columnView, 3, Align.End);
 
 
         _columnView.OnRealize += (_, _) => { Reload(); };
@@ -216,7 +222,8 @@ public class AurUpdate(
         _filter.Changed(FilterChange.Different);
     }
 
-    private void SetupColumns(ColumnViewColumn checkColumn, ColumnViewColumn nameColumn, ColumnViewColumn versionColumn)
+    private void SetupColumns(ColumnViewColumn checkColumn, ColumnViewColumn nameColumn, ColumnViewColumn oldColumn,
+        ColumnViewColumn versionColumn)
     {
         _checkFactory = SignalListItemFactory.New();
         _checkFactory.OnSetup += (_, args) =>
@@ -288,6 +295,23 @@ public class AurUpdate(
         };
         nameColumn.SetFactory(_nameFactory);
 
+        _oldVersionFactory = SignalListItemFactory.New();
+        _oldVersionFactory.OnSetup += (_, args) =>
+        {
+            if (args.Object is not ColumnViewCell listItem) return;
+            var label = Label.New(string.Empty);
+            listItem.SetChild(label);
+        };
+        _oldVersionFactory.OnBind += (_, args) =>
+        {
+            if (args.Object is not ColumnViewCell listItem) return;
+            if (listItem.GetItem() is not AurUpdateGObject { Package: { } pkg } ||
+                listItem.GetChild() is not Label label) return;
+            label.SetText(pkg.Version);
+            label.Halign = Align.End;
+        };
+        oldColumn.SetFactory(_oldVersionFactory);
+
         _versionFactory = SignalListItemFactory.New();
         _versionFactory.OnSetup += (_, args) =>
         {
@@ -300,7 +324,7 @@ public class AurUpdate(
             if (args.Object is not ColumnViewCell listItem) return;
             if (listItem.GetItem() is not AurUpdateGObject { Package: { } pkg } ||
                 listItem.GetChild() is not Label label) return;
-            label.SetText(pkg.Version);
+            label.SetText(pkg.NewVersion);
             label.Halign = Align.End;
         };
         versionColumn.SetFactory(_versionFactory);


### PR DESCRIPTION
Currently, for AUR updates, there is just a "Version" column that shows the current version. This seems redundant and quite possibly misleading. I kept thinking these were the *new* versions available and getting confused.

So, following the exact same convention of the main Updates tab, I have attempted to add Old Version/Version columns for the AUR. I mostly just copy/pasted and renamed some stuff and it appears to work.

The only real consideration I can think of seems to be VCS packages like the -git stuff, which fallback to a literal "latest-commit", similar to what command-line AUR helpers (and I believe Shelly itself) do.

I also made a minor adjustment to column padding omitting expand=true in the .ui file, to make it consistent with the main update tab. (I think there are a few inconsistencies surrounding this in particular but that's another job.)