### PR TITLE
Create update-translations.sh

### DIFF
--- a/update-translations.sh
+++ b/update-translations.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cd Shelly.Gtk/po/
+
+find .. -type f \( -name "*.cs" -or -name "*.ui" \) | \
+    xgettext --no-location --keyword=T -o shelly-ui.pot \
+            --from-code=UTF-8 -f -
+
+for f in *.po
+do
+    msgmerge --no-location --update --backup=none "$f" shelly-ui.pot
+done
+
+cd -
+cd Shelly-Notifications/po/
+
+find .. -type f \( -name "*.cs" -or -name "*.ui" \) | \
+    xgettext --no-location --keyword=T -o shelly-notifications.pot \
+            --from-code=UTF-8 -f -
+
+for f in *.po
+do
+    msgmerge --no-location --update --backup=none "$f" shelly-notifications.pot
+done
+
+cd -


### PR DESCRIPTION
It generates  the latest "shelly-ui.pot" and generates the PO files based on it.
It also do it for "shelly-notifications.pot".

I think the current "shelly-ui.pot" lacks over 20 messages and includes some obsolete messages.
Run "sh update-translations.sh" and open "Shelly.Gtk/po/pl.po" by poedit please.
See also https://github.com/Seafoam-Labs/Shelly-ALPM/pull/1148 .