### PR TITLE
1064 bug text cut off from last part of aur pkgbuild preview

### DIFF
--- a/Shelly.Gtk/Services/PkgBuildService.cs
+++ b/Shelly.Gtk/Services/PkgBuildService.cs
@@ -46,7 +46,8 @@ public class PkgBuildService : IPkgBuildService
             {
                 var args = new PackageBuildEventArgs($"PKGBUILD: {packageName}", content, sourceFiles);
             
-                PkgbuildPreview.ShowPackageBuildPreview(args, questionService);
+                var parent = (Gio.Application.GetDefault() as Application)?.GetActiveWindow();
+                PkgbuildPreview.ShowPackageBuildPreview(parent, args);
             
                 return false; 
             });

--- a/Shelly.Gtk/Services/PkgBuildService.cs
+++ b/Shelly.Gtk/Services/PkgBuildService.cs
@@ -46,7 +46,7 @@ public class PkgBuildService : IPkgBuildService
             {
                 var args = new PackageBuildEventArgs($"PKGBUILD: {packageName}", content, sourceFiles);
             
-                PkgbuildPreview.ShowPackageBuildPreview(parentOverlay, args, questionService);
+                PkgbuildPreview.ShowPackageBuildPreview(args, questionService);
             
                 return false; 
             });

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -43,7 +43,6 @@ public static class PkgbuildPreview
             {
                 var clipboard = copyButton.GetClipboard();
                 clipboard.SetText(e.PkgBuild);
-                questionService.RaiseToastMessage(new ToastMessageEventArgs("PKGBUILD copied to clipboard"));
             };
         }
 

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -3,64 +3,35 @@ using Pango;
 using Shelly.Gtk.Services;
 using Shelly.Gtk.UiModels;
 using WrapMode = Gtk.WrapMode;
-
+ 
 namespace Shelly.Gtk.Windows.Dialog;
-
+ 
 public static class PkgbuildPreview
 {
-    public static void ShowPackageBuildPreview(PackageBuildEventArgs e, IGenericQuestionService questionService)
+    public static void ShowPackageBuildPreview(Window? parent, PackageBuildEventArgs? e)
     {
-        var tcs = new TaskCompletionSource<bool>(); // Opcional: se quiser usar como Task<bool> no futuro
-
+        if (e is null) return;
+        
+        var tcs = new TaskCompletionSource<bool>();
+ 
         var dialog = Window.New();
         
         dialog.SetTitle(e.Title);                      
-        dialog.SetTransientFor(null);                  
+        dialog.SetTransientFor(parent);                  
         dialog.SetModal(true);                         
-        dialog.SetDefaultSize(900, 650);               
-
+        dialog.SetDefaultSize(900, 650);    
+        dialog.SetResizable(true);
+ 
         var outer = Box.New(Orientation.Vertical, 12);
-        
-        var headerBox = Box.New(Orientation.Horizontal, 0);
-        headerBox.SetMarginTop(4);
-
-        var closeButton = Button.New();
-        closeButton.SetIconName("window-close-symbolic");
-        closeButton.TooltipText = "Close Preview";
-        
-        closeButton.OnClicked += (_, _) =>
-        {
-            tcs.TrySetResult(false);
-            dialog.Close();
-        };
-
-        var copyButton = Button.New();
+ 
+        var notebook = Notebook.New();
+        notebook.SetVexpand(true);
+        notebook.SetHexpand(true);
+        notebook.SetScrollable(true);
+ 
         if (!string.IsNullOrEmpty(e.PkgBuild))
         {
-            copyButton.SetIconName("edit-copy-symbolic"); 
-            copyButton.TooltipText = "Copy PKGBUILD to clipboard";
-            copyButton.OnClicked += (_, _) =>
-            {
-                var clipboard = copyButton.GetClipboard();
-                clipboard.SetText(e.PkgBuild);
-            };
-        }
-
-        var titleLabel = Label.New(e.Title);
-        titleLabel.AddCssClass("title-4");
-        titleLabel.SetHexpand(true);
-        titleLabel.SetXalign(0.5f);
-        titleLabel.SetMarginEnd(40);
-
-        headerBox.Append(copyButton);
-        headerBox.Append(titleLabel);
-        headerBox.Append(closeButton);
-
-        outer.Append(headerBox);
-
-        var textView = TextView.New();
-        if (!string.IsNullOrEmpty(e.PkgBuild))
-        {
+            var textView = TextView.New();
             textView.WrapMode = WrapMode.WordChar;
             textView.Editable = false;          
             textView.Monospace = true;        
@@ -70,27 +41,21 @@ public static class PkgbuildPreview
             textView.TopMargin = 12;
             textView.BottomMargin = 12;
             textView.GetBuffer().SetText(e.PkgBuild, -1);
-
+ 
             var scrolledWindow = ScrolledWindow.New();
             scrolledWindow.SetPolicy(PolicyType.Automatic, PolicyType.Automatic);
             scrolledWindow.SetVexpand(true);
             scrolledWindow.SetHexpand(true);
             scrolledWindow.AddCssClass("view"); 
             scrolledWindow.SetChild(textView);
-
-            outer.Append(scrolledWindow);
+ 
+            notebook.AppendPage(scrolledWindow, Label.New("PKGBUILD"));
         }
         
         foreach (var (name, content) in e.SourceFiles)
         {
             if (string.IsNullOrEmpty(content)) continue;
-
-            var sourceLabel = Label.New(name);
-            sourceLabel.AddCssClass("heading");
-            sourceLabel.SetXalign(0);
-            sourceLabel.SetMarginStart(12);
-            outer.Append(sourceLabel);
-
+ 
             var sourceView = TextView.New();
             sourceView.SetWrapMode(WrapMode.WordChar);
             sourceView.Editable = false;
@@ -101,26 +66,28 @@ public static class PkgbuildPreview
             sourceView.TopMargin = 12;
             sourceView.BottomMargin = 12;
             sourceView.GetBuffer().SetText(content, -1);
-
+ 
             var sourceScroll = ScrolledWindow.New();
             sourceScroll.SetPolicy(PolicyType.Automatic, PolicyType.Automatic);
             sourceScroll.SetVexpand(true);
             sourceScroll.SetHexpand(true);
             sourceScroll.AddCssClass("view");
             sourceScroll.SetChild(sourceView);
-            outer.Append(sourceScroll);
+ 
+            notebook.AppendPage(sourceScroll, Label.New(name));
         }
-
+ 
+        outer.Append(notebook);
+ 
         dialog.SetChild(outer);
-
+ 
         dialog.OnCloseRequest += (_, _) =>
         {
             tcs.TrySetResult(false);
+            dialog.Dispose();
             return false;
         };
-
+ 
         dialog.Present();
-
-        closeButton.GrabFocus();
     }
 }

--- a/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
+++ b/Shelly.Gtk/Windows/Dialog/PkgbuildPreview.cs
@@ -8,54 +8,48 @@ namespace Shelly.Gtk.Windows.Dialog;
 
 public static class PkgbuildPreview
 {
-    public static void ShowPackageBuildPreview(Overlay parentOverlay, PackageBuildEventArgs e, IGenericQuestionService questionService)
+    public static void ShowPackageBuildPreview(PackageBuildEventArgs e, IGenericQuestionService questionService)
     {
-        var background = Box.New(Orientation.Horizontal, 0);
-        background.AddCssClass("lockout-overlay");
-        background.SetHalign(Align.Fill);
-        background.SetValign(Align.Fill);
-        background.SetHexpand(true);
-        background.SetVexpand(true);
+        var tcs = new TaskCompletionSource<bool>(); // Opcional: se quiser usar como Task<bool> no futuro
 
-        var baseFrame = Frame.New(null);
-        baseFrame.SetHalign(Align.Center);
-        baseFrame.SetValign(Align.Center);
-        baseFrame.SetSizeRequest(900, 600); 
-        baseFrame.SetMarginTop(20);
-        baseFrame.SetMarginBottom(20);
-        baseFrame.SetMarginStart(20);
-        baseFrame.SetMarginEnd(20);
-        baseFrame.AddCssClass("background");
-        baseFrame.AddCssClass("dialog-overlay");
-        baseFrame.SetOverflow(Overflow.Hidden);
-        background.Append(baseFrame);
+        var dialog = Window.New();
+        
+        dialog.SetTitle(e.Title);                      
+        dialog.SetTransientFor(null);                  
+        dialog.SetModal(true);                         
+        dialog.SetDefaultSize(900, 650);               
 
-        var box = Box.New(Orientation.Vertical, 12);
-        baseFrame.SetChild(box);
-
+        var outer = Box.New(Orientation.Vertical, 12);
+        
         var headerBox = Box.New(Orientation.Horizontal, 0);
         headerBox.SetMarginTop(4);
-        headerBox.SetMarginStart(4);
 
         var closeButton = Button.New();
         closeButton.SetIconName("window-close-symbolic");
         closeButton.TooltipText = "Close Preview";
-        closeButton.OnClicked += (_, _) => Close();
         
-        var copyButton = Button.New();
-        copyButton.SetIconName("edit-copy-symbolic"); 
-        copyButton.TooltipText = "Copy PKGBUILD to clipboard";
-        copyButton.OnClicked += (_, _) =>
+        closeButton.OnClicked += (_, _) =>
         {
-            var clipboard = copyButton.GetClipboard();
-            clipboard.SetText(e.PkgBuild);
-            questionService.RaiseToastMessage(new ToastMessageEventArgs("PKGBUILD copied to clipboard"));
+            tcs.TrySetResult(false);
+            dialog.Close();
         };
+
+        var copyButton = Button.New();
+        if (!string.IsNullOrEmpty(e.PkgBuild))
+        {
+            copyButton.SetIconName("edit-copy-symbolic"); 
+            copyButton.TooltipText = "Copy PKGBUILD to clipboard";
+            copyButton.OnClicked += (_, _) =>
+            {
+                var clipboard = copyButton.GetClipboard();
+                clipboard.SetText(e.PkgBuild);
+                questionService.RaiseToastMessage(new ToastMessageEventArgs("PKGBUILD copied to clipboard"));
+            };
+        }
 
         var titleLabel = Label.New(e.Title);
         titleLabel.AddCssClass("title-4");
         titleLabel.SetHexpand(true);
-        titleLabel.SetHalign(Align.Center);
         titleLabel.SetXalign(0.5f);
         titleLabel.SetMarginEnd(40);
 
@@ -63,37 +57,40 @@ public static class PkgbuildPreview
         headerBox.Append(titleLabel);
         headerBox.Append(closeButton);
 
-        box.Append(headerBox);
-        
+        outer.Append(headerBox);
 
         var textView = TextView.New();
-        textView.SetWrapMode(WrapMode.WordChar);
-        textView.Editable = false;          
-        textView.Monospace = true;        
-        textView.CursorVisible = false;
-        textView.LeftMargin = 12;
-        textView.RightMargin = 12;
-        textView.TopMargin = 12;
-        textView.BottomMargin = 12;
-        
-        textView.GetBuffer().SetText(e.PkgBuild, -1);
+        if (!string.IsNullOrEmpty(e.PkgBuild))
+        {
+            textView.WrapMode = WrapMode.WordChar;
+            textView.Editable = false;          
+            textView.Monospace = true;        
+            textView.CursorVisible = false;
+            textView.LeftMargin = 12;
+            textView.RightMargin = 12;
+            textView.TopMargin = 12;
+            textView.BottomMargin = 12;
+            textView.GetBuffer().SetText(e.PkgBuild, -1);
 
-        var scrolledWindow = ScrolledWindow.New();
-        scrolledWindow.SetPolicy(PolicyType.Automatic, PolicyType.Automatic);
-        scrolledWindow.SetVexpand(true);
-        scrolledWindow.SetHexpand(true);
-        scrolledWindow.AddCssClass("view"); 
-        scrolledWindow.SetChild(textView);
-        
-        box.Append(scrolledWindow);
+            var scrolledWindow = ScrolledWindow.New();
+            scrolledWindow.SetPolicy(PolicyType.Automatic, PolicyType.Automatic);
+            scrolledWindow.SetVexpand(true);
+            scrolledWindow.SetHexpand(true);
+            scrolledWindow.AddCssClass("view"); 
+            scrolledWindow.SetChild(textView);
 
+            outer.Append(scrolledWindow);
+        }
+        
         foreach (var (name, content) in e.SourceFiles)
         {
+            if (string.IsNullOrEmpty(content)) continue;
+
             var sourceLabel = Label.New(name);
             sourceLabel.AddCssClass("heading");
             sourceLabel.SetXalign(0);
             sourceLabel.SetMarginStart(12);
-            box.Append(sourceLabel);
+            outer.Append(sourceLabel);
 
             var sourceView = TextView.New();
             sourceView.SetWrapMode(WrapMode.WordChar);
@@ -112,26 +109,19 @@ public static class PkgbuildPreview
             sourceScroll.SetHexpand(true);
             sourceScroll.AddCssClass("view");
             sourceScroll.SetChild(sourceView);
-            box.Append(sourceScroll);
+            outer.Append(sourceScroll);
         }
 
-        var shortcutController = ShortcutController.New();
-        shortcutController.Scope = ShortcutScope.Global;
-        
-        var escAction = CallbackAction.New((_, _) => {
-            Close();
-            return true;
-        });
-        shortcutController.AddShortcut(Shortcut.New(ShortcutTrigger.ParseString("Escape"), escAction));
-        background.AddController(shortcutController);
+        dialog.SetChild(outer);
 
-        parentOverlay.AddOverlay(background);
-        return;
-
-        void Close()
+        dialog.OnCloseRequest += (_, _) =>
         {
-            e.SetResponse(false);
-            parentOverlay.RemoveOverlay(background);
-        }
+            tcs.TrySetResult(false);
+            return false;
+        };
+
+        dialog.Present();
+
+        closeButton.GrabFocus();
     }
 }


### PR DESCRIPTION
This PR changes the pkgbuild preview window from a fixed dialog overlay into a draggable and resizeable window. 

It also adds management for PKGBUILDs that include multiple files, adding a tabbed UI to improve ease of use.

<img width="1119" height="836" alt="image" src="https://github.com/user-attachments/assets/bf76d0b6-db22-42c4-9733-df1b09318ae5" />
