### PR TITLE
feat(i18n): extract hardcoded GTK strings into gettext

### DIFF
--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -851,7 +851,7 @@ sealed class Program
                     if (packagesNeedingUpdate.Aur.Count == 0 && packagesNeedingUpdate.Packages.Count == 0 &&
                         packagesNeedingUpdate.Flatpak.Count == 0)
                     {
-                        var toastArgs = new ToastMessageEventArgs("No packages need to be upgraded");
+                        var toastArgs = new ToastMessageEventArgs(T("No packages need to be upgraded"));
                         genericQuestionService.RaiseToastMessage(toastArgs);
                         return;
                     }
@@ -859,7 +859,7 @@ sealed class Program
                     if (!configService.LoadConfig().NoConfirm)
                     {
                         var confirmArgs = new GenericQuestionEventArgs(
-                            "Upgrade All Packages?",
+                            T("Upgrade All Packages?"),
                             BottomBarExtensions.BuildUpgradeConfirmationMessage(packagesNeedingUpdate),
                             true
                         );
@@ -871,7 +871,7 @@ sealed class Program
                         }
                     }
 
-                    lockoutService.Show("Upgrading all packages...");
+                    lockoutService.Show(T("Upgrading all packages..."));
 
                     // The PKGBUILD review/diff is now surfaced through the unified
                     // wire-based PkgbuildReviewDialog during the operation, so the
@@ -880,8 +880,8 @@ sealed class Program
                     if (upgradeResult.NeedsReboot)
                     {
                         var rebootArgs = new GenericQuestionEventArgs(
-                            "Reboot Required",
-                            "A full system reboot is required for updates to take effect.\n\nWould you like to reboot now?",
+                            T("Reboot Required"),
+                            T("A full system reboot is required for updates to take effect.\n\nWould you like to reboot now?"),
                             true
                         );
                         genericQuestionService.RaiseQuestion(rebootArgs);
@@ -895,8 +895,8 @@ sealed class Program
                         var failureList = string.Join("\n", upgradeResult.FailedServiceRestarts
                             .Select(f => $"  • {f.Service}: {f.Error}"));
                         var failArgs = new GenericQuestionEventArgs(
-                            "Service Restart Failures",
-                            $"The following services failed to restart automatically:\n{failureList}",
+                            T("Service Restart Failures"),
+                            T("The following services failed to restart automatically:\n{0}", failureList),
                             false
                         );
                         genericQuestionService.RaiseQuestion(failArgs);

--- a/Shelly.Gtk/Services/PkgBuildService.cs
+++ b/Shelly.Gtk/Services/PkgBuildService.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Gtk;
 using Shelly.Gtk.Windows.Dialog;
 using Shelly.Gtk.UiModels;
+using static Shelly.GTK.Resources.Translations;
 
 namespace Shelly.Gtk.Services;
 
@@ -23,7 +24,7 @@ public class PkgBuildService : IPkgBuildService
             if (!response.IsSuccessStatusCode)
             {
                 GLib.Functions.IdleAdd(0, () => {
-                    questionService.RaiseToastMessage(new ToastMessageEventArgs($"PKGBUILD for '{packageName}' not found."));
+                    questionService.RaiseToastMessage(new ToastMessageEventArgs(T("PKGBUILD for '{0}' not found.", packageName)));
                     return false;
                 });      
                 return;
@@ -34,7 +35,7 @@ public class PkgBuildService : IPkgBuildService
             if (string.IsNullOrWhiteSpace(content))
             {
                 GLib.Functions.IdleAdd(0, () => {
-                    questionService.RaiseToastMessage(new ToastMessageEventArgs("The PKGBUILD is empty."));
+                    questionService.RaiseToastMessage(new ToastMessageEventArgs(T("The PKGBUILD is empty.")));
                     return false;
                 });                
                 return;
@@ -44,7 +45,7 @@ public class PkgBuildService : IPkgBuildService
 
             GLib.Functions.IdleAdd(0, () => 
             {
-                var args = new PackageBuildEventArgs($"PKGBUILD: {packageName}", content, sourceFiles);
+                var args = new PackageBuildEventArgs(T("PKGBUILD: {0}", packageName), content, sourceFiles);
             
                 var parent = (Gio.Application.GetDefault() as Application)?.GetActiveWindow();
                 PkgbuildPreview.ShowPackageBuildPreview(parent, args);

--- a/Shelly.Gtk/UiFiles/Dialogs/QuestionDialog.ui
+++ b/Shelly.Gtk/UiFiles/Dialogs/QuestionDialog.ui
@@ -2,7 +2,7 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
   <object class="GtkWindow" id="QuestionDialog">
-    <property name="title">Confirm Action</property>
+    <property name="title" translatable="yes">Confirm Action</property>
     <property name="modal">true</property>
     <child>
       <object class="GtkBox">
@@ -14,7 +14,7 @@
         <property name="spacing">15</property>
         <child>
           <object class="GtkLabel" id="question_label">
-            <property name="label">Are you sure?</property>
+            <property name="label" translatable="yes">Are you sure?</property>
           </object>
         </child>
         <child>
@@ -23,12 +23,12 @@
             <property name="spacing">10</property>
             <child>
               <object class="GtkButton" id="no_button">
-                <property name="label">No</property>
+                <property name="label" translatable="yes">No</property>
               </object>
             </child>
             <child>
               <object class="GtkButton" id="yes_button">
-                <property name="label">Yes</property>
+                <property name="label" translatable="yes">Yes</property>
                 <style>
                   <class name="suggested-action"/>
                 </style>

--- a/Shelly.Gtk/UiFiles/MainMenu.ui
+++ b/Shelly.Gtk/UiFiles/MainMenu.ui
@@ -3,23 +3,23 @@
   <menu id="AppMenu">
     <section>
       <submenu>
-        <attribute name="label">_File</attribute>
+        <attribute name="label" translatable="yes">_File</attribute>
         <item>
-          <attribute name="label">_Quit</attribute>
+          <attribute name="label" translatable="yes">_Quit</attribute>
           <attribute name="action">app.quit</attribute>
         </item>
       </submenu>
       <submenu>
-        <attribute name="label">_Edit</attribute>
+        <attribute name="label" translatable="yes">_Edit</attribute>
         <item>
-          <attribute name="label">_Preferences</attribute>
+          <attribute name="label" translatable="yes">_Preferences</attribute>
           <attribute name="action">app.preferences</attribute>
         </item>
       </submenu>
       <submenu>
-        <attribute name="label">_Help</attribute>
+        <attribute name="label" translatable="yes">_Help</attribute>
         <item>
-          <attribute name="label">_About</attribute>
+          <attribute name="label" translatable="yes">_About</attribute>
           <attribute name="action">app.about</attribute>
         </item>
       </submenu>

--- a/Shelly.Gtk/UiFiles/Package/RemoveLocalWindow.ui
+++ b/Shelly.Gtk/UiFiles/Package/RemoveLocalWindow.ui
@@ -14,7 +14,7 @@
                 <child>
                     <object class="GtkButton" id="remove_button">
                         <property name="halign">start</property>
-                        <property name="label">Remove Selected</property>
+                        <property name="label" translatable="yes">Remove Selected</property>
                         <style>
                             <class name="destructive-action"/>
                         </style>
@@ -46,13 +46,13 @@
                                 </child>
                                 <child>
                                     <object class="GtkColumnViewColumn" id="name_column">
-                                        <property name="title">Package Name</property>
+                                        <property name="title" translatable="yes">Package Name</property>
                                         <property name="expand">true</property>
                                     </object>
                                 </child>
                                 <child>
                                     <object class="GtkColumnViewColumn" id="size_column">
-                                        <property name="title">Size</property>
+                                        <property name="title" translatable="yes">Size</property>
                                     </object>
                                 </child>
                             </object>

--- a/Shelly.Gtk/Windows/AppImage.cs
+++ b/Shelly.Gtk/Windows/AppImage.cs
@@ -67,8 +67,9 @@ public sealed class AppImage(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/AppImage.ui"), -1);
+        var builder = Builder.New();
         builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/AppImage.ui"), -1);
         _listPage = (Box)builder.GetObject("AppImagePage")!;
         _detailPage = (ScrolledWindow)builder.GetObject("AppImageDetailView")!;
         _appListBox = (ListBox)builder.GetObject("AppImageListBox")!;

--- a/Shelly.Gtk/Windows/Flatpak/FlatpakInstall.cs
+++ b/Shelly.Gtk/Windows/Flatpak/FlatpakInstall.cs
@@ -110,7 +110,9 @@ public class FlatpakInstall(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Flatpak/FlatpakInstallWindow.ui"), -1);
+        var builder = Builder.New();
+        builder.TranslationDomain = Translations.Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Flatpak/FlatpakInstallWindow.ui"), -1);
         var box = (Box)builder.GetObject("FlatpakInstallWindow")!;
         FlatpakRefHandler.InstallRequested += OnInstallRequested;
 
@@ -857,9 +859,9 @@ public class FlatpakInstall(
         verifiedIcon.Halign = Align.Start;
         verifiedIcon.Hexpand = false;
         verifiedIcon.Vexpand = false;
-        verifiedIcon.TooltipText = "Verified";
+        verifiedIcon.TooltipText = Translations.T("Verified");
         titleGrid.Attach(verifiedIcon, 1, 0, 1, 1);
-        
+
         rightBox.Append(titleGrid);
 
         var idLabel = Label.New(string.Empty);

--- a/Shelly.Gtk/Windows/Flatpak/FlatpakManage.cs
+++ b/Shelly.Gtk/Windows/Flatpak/FlatpakManage.cs
@@ -32,7 +32,9 @@ public class FlatpakManage(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Flatpak/FlatpakRemoveWindow.ui"), -1);
+        var builder = Builder.New();
+        builder.TranslationDomain = Translations.Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Flatpak/FlatpakRemoveWindow.ui"), -1);
         var box = (Box)builder.GetObject("FlatpakRemoveWindow")!;
 
         _listView = (ListView)builder.GetObject("installed_flatpaks")!;
@@ -159,7 +161,7 @@ public class FlatpakManage(
         catch (OperationCanceledException)
         {
             genericQuestionService.RaiseToastMessage(new ToastMessageEventArgs(
-                Translations.T($"Failed to repair Flatpak installation")));
+                Translations.T("Failed to repair Flatpak installation")));
         }
         finally
         {

--- a/Shelly.Gtk/Windows/Flatpak/FlatpakUpdate.cs
+++ b/Shelly.Gtk/Windows/Flatpak/FlatpakUpdate.cs
@@ -32,7 +32,9 @@ public class FlatpakUpdate(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Flatpak/FlatpakUpdateWindow.ui"), -1);
+        var builder = Builder.New();
+        builder.TranslationDomain = Translations.Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Flatpak/FlatpakUpdateWindow.ui"), -1);
         var box = (Box)builder.GetObject("FlatpakUpdateWindow")!;
 
         _listView = (ListView)builder.GetObject("installed_flatpaks")!;

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -73,8 +73,9 @@ public sealed class PackageInstall(
     
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Package/PackageWindow.ui"), -1);
+        var builder = Builder.New();
         builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Package/PackageWindow.ui"), -1);
         _overlay = (Overlay)builder.GetObject("PackageWindow")!;
         var columnView = (ColumnView)builder.GetObject("package_column_view")!;
         _scroller = (ScrolledWindow)columnView.GetParent()!;
@@ -893,7 +894,7 @@ public sealed class PackageInstall(
             label.SetText(pkg.Name);
             label.Halign = Align.Start;
             installedIcon.Visible = pkgObj.IsInstalled;
-            installedIcon.TooltipText = "Installed";
+            installedIcon.TooltipText = T("Installed");
         };
         nameColumn.SetFactory(nameFactory);
 

--- a/Shelly.Gtk/Windows/Packages/PackageManagement.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageManagement.cs
@@ -79,8 +79,9 @@ public sealed class PackageManagement(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Package/PackageManagement.ui"), -1);
+        var builder = Builder.New();
         builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Package/PackageManagement.ui"), -1);
         _box = (Overlay)builder.GetObject("PackageManagement")!;
         _columnView = (ColumnView)builder.GetObject("package_grid")!;
         var columnView = _columnView;

--- a/Shelly.Gtk/Windows/Packages/RemoveLocal.cs
+++ b/Shelly.Gtk/Windows/Packages/RemoveLocal.cs
@@ -3,6 +3,7 @@ using Shelly.Gtk.Helpers;
 using Shelly.Gtk.Services;
 using Shelly.Gtk.UiModels;
 using Shelly.Gtk.UiModels.PackageManagerObjects.GObjects;
+using static Shelly.GTK.Resources.Translations;
 using Functions = GLib.Functions;
 using ListStore = Gio.ListStore;
 
@@ -26,7 +27,9 @@ public sealed class RemoveLocal(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Package/RemoveLocalWindow.ui"), -1);
+        var builder = Builder.New();
+        builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Package/RemoveLocalWindow.ui"), -1);
         var box = (Box)builder.GetObject("RemoveLocalWindow")!;
         var columnView = (ColumnView)builder.GetObject("package_grid")!;
 
@@ -227,7 +230,7 @@ public sealed class RemoveLocal(
             if (!configService.LoadConfig().NoConfirm)
             {
                 var args = new GenericQuestionEventArgs(
-                    "Remove Packages?", string.Join("\n", selectedPackages)
+                    T("Remove Packages?"), string.Join("\n", selectedPackages)
                 );
 
                 genericQuestionService.RaiseQuestion(args);
@@ -239,12 +242,12 @@ public sealed class RemoveLocal(
 
             try
             {
-                lockoutService.Show("Removing...");
+                lockoutService.Show(T("Removing..."));
                 var result = await privilegedOperationService.RemoveLocalPackagesAsync(selectedPackages);
                 if (result.Success)
                 {
                     var args = new ToastMessageEventArgs(
-                        $"Removed {selectedPackages.Count} Package(s)"
+                        T("Removed {0} Package(s)", selectedPackages.Count)
                     );
                     genericQuestionService.RaiseToastMessage(args);
                 }

--- a/Shelly.Gtk/Windows/Recommend.cs
+++ b/Shelly.Gtk/Windows/Recommend.cs
@@ -53,8 +53,9 @@ public sealed class Recommend(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/Recommend.ui"), -1);
+        var builder = Builder.New();
         builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/Recommend.ui"), -1);
         var overlay = (Overlay)builder.GetObject("ShellyRecommend")!;
 
         _scrolledWindow = (Box)builder.GetObject("recommend_scroll_window")!;

--- a/Shelly.Gtk/Windows/Settings.cs
+++ b/Shelly.Gtk/Windows/Settings.cs
@@ -80,7 +80,9 @@ public sealed class Settings(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/SettingWindow.ui"), -1);
+        var builder = Builder.New();
+        builder.TranslationDomain = Translations.Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/SettingWindow.ui"), -1);
         _box = (Box)builder.GetObject("SettingWindow")!;
 
         _config = configService.LoadConfig();

--- a/Shelly.Gtk/Windows/SetupWindow.cs
+++ b/Shelly.Gtk/Windows/SetupWindow.cs
@@ -23,7 +23,9 @@ public sealed class SetupWindow(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/SetupWindow.ui"), -1);
+        var builder = Builder.New();
+        builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/SetupWindow.ui"), -1);
         _box = (Box)builder.GetObject("SetupWindow")!;
 
         var aurCheck = (CheckButton)builder.GetObject("aur_check")!;

--- a/Shelly.Gtk/Windows/ShellySearch.cs
+++ b/Shelly.Gtk/Windows/ShellySearch.cs
@@ -37,8 +37,9 @@ public sealed class ShellySearch(
 
     public Widget CreateWindow()
     {
-        var builder = Builder.NewFromString(ResourceHelper.LoadUiFile("UiFiles/ShellySearchWindow.ui"), -1);
+        var builder = Builder.New();
         builder.TranslationDomain = Domain;
+        builder.AddFromString(ResourceHelper.LoadUiFile("UiFiles/ShellySearchWindow.ui"), -1);
         var box = (Box)builder.GetObject("ShellySearchWindow")!;
         var columnView = (ColumnView)builder.GetObject("package_grid")!;
         _installButton = (Button)builder.GetObject("install_button")!;
@@ -485,7 +486,7 @@ public sealed class ShellySearch(
 
         try
         {
-            lockoutService.Show(T($"Installing..."));
+            lockoutService.Show(T("Installing..."));
             var standard = selected.Where(x => x.PackageType == PackageType.Standard).Select(x => x.Name).ToList();
             var aur = selected.Where(x => x.PackageType == PackageType.Aur).Select(x => x.Name).ToList();
             var flatpak = selected.Where(x => x.PackageType == PackageType.Flatpak).Select(x => x.Id).ToList();

--- a/Shelly.Gtk/po/shelly-ui.pot
+++ b/Shelly.Gtk/po/shelly-ui.pot
@@ -1496,12 +1496,6 @@ msgstr ""
 msgid "Failed to remove packages: {0}"
 msgstr ""
 
-msgid "Changes"
-msgstr ""
-
-msgid "Review Changes"
-msgstr ""
-
 msgid "Package Statistics"
 msgstr ""
 
@@ -1518,4 +1512,51 @@ msgid "Up to date"
 msgstr ""
 
 msgid "Calculating"
+msgstr ""
+
+msgid "No packages need to be upgraded"
+msgstr ""
+
+msgid "Upgrade All Packages?"
+msgstr ""
+
+msgid "Upgrading all packages..."
+msgstr ""
+
+#, csharp-format
+msgid "PKGBUILD for '{0}' not found."
+msgstr ""
+
+msgid "The PKGBUILD is empty."
+msgstr ""
+
+#, csharp-format
+msgid "PKGBUILD: {0}"
+msgstr ""
+
+msgid "Verified"
+msgstr ""
+
+msgid "_File"
+msgstr ""
+
+msgid "_Quit"
+msgstr ""
+
+msgid "_Edit"
+msgstr ""
+
+msgid "_Preferences"
+msgstr ""
+
+msgid "_Help"
+msgstr ""
+
+msgid "_About"
+msgstr ""
+
+msgid "Confirm Action"
+msgstr ""
+
+msgid "Are you sure?"
 msgstr ""


### PR DESCRIPTION
Wraps the remaining hardcoded GTK UI strings in the `shelly-ui` gettext domain, so they become translatable.

## Changes
- Wrap hardcoded user-facing strings in `.cs`/`.ui` with `T(...)` and set `builder.TranslationDomain` where builders were created without a domain.
- Add the new `msgid` entries to `shelly-ui.pot`.
- Deduplicate `shelly-ui.pot` (master had accidental duplicate msgids: `Changes`, `Review Changes`).

## Notes
- **Split out from the previous PR** per review feedback — this one contains **only the code extractions**. French translations follow in a separate PR.
- Builds cleanly (`dotnet build`, 0 errors).