### PR TITLE
fix(settings-ui): wire up shelly_icons_switch to ShellyIconsEnabled

### DIFF
--- a/Shelly.Gtk/Windows/Settings.cs
+++ b/Shelly.Gtk/Windows/Settings.cs
@@ -104,6 +104,7 @@ public sealed class Settings(
             (v) => _config.PackageDowngradeEnabled = v,
             builder);
         SetupSwitch("use_old_menu_switch", !_config.UseOldMenu, (v) => _config.UseOldMenu = !v, builder);
+        SetupSwitch("shelly_icons_switch", _config.ShellyIconsEnabled, (v) => _config.ShellyIconsEnabled = v, builder);
         SetupTrayAutoStart("tray_auto_switch", _config.TrayAutoStart, (v) => _config.TrayAutoStart = v, builder);
 
         var parallelDownloadsSpin = (SpinButton)builder.GetObject("parallel_downloads_spin")!;


### PR DESCRIPTION
The switch was defined in SettingWindow.ui but its SetupSwitch call was accidentally dropped in 48dc93cf, leaving it visually present but non-functional.