### PR TITLE
Remove Seafoam Labs website deployment step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Deploy Seafoam Labs website
-        uses: digitalocean/app_action/deploy@v2
-        with:
-          app_name: seafoam-labs-website
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}


### PR DESCRIPTION
Removing due to failure in release workflow: https://github.com/Seafoam-Labs/Shelly-ALPM/actions/runs/28714234534/job/85152732855

Maybe it is possible to set-up, but it didn't work out for me. I used full scoped app token, yet it still shows 403.