### PR TITLE
fix: Raise and focus existing shelly-ui window on tray activation

### DIFF
--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -217,17 +217,14 @@ sealed class Program
         application.AddAction(quitAction);
         application.SetAccelsForAction("app.quit", ["<Ctrl>Q"]);
 
+        // Fired when another process (e.g. shelly-notifications) calls
+        // org.freedesktop.Application.Activate on our bus name.
+        application.OnActivate += (_, _) => _window?.Present();
+
         application.OnStartup += (_, _) =>
         {
             if (initialConfig.TrayEnabled)
                 TrayStartService.Start();
-
-            var existingWindow = application.GetActiveWindow();
-            if (existingWindow != null)
-            {
-                existingWindow.Present();
-                return;
-            }
 
             var cssProvider = CssProvider.New();
             cssProvider.LoadFromString(ResourceHelper.LoadAsset("Assets/style.css"));

--- a/Shelly.Notifications/src/app_runner.vala
+++ b/Shelly.Notifications/src/app_runner.vala
@@ -7,9 +7,34 @@ public class AppRunner {
         "/opt/shelly/Shelly-UI"
     };
 
-    public static void launch_app_if_not_running () {
-        if (is_process_running ("shelly-ui")) {
-            stdout.printf ("[shelly-runner] shelly-ui is already running\n");
+    private const string SHELLY_UI_SERVICE = "com.shellyorg.shelly";
+    private const string SHELLY_UI_PATH = "/com/shellyorg/shelly";
+
+    private static string? _activation_token = null;
+
+    /*
+     * Stores the single-use XDG activation token that the tray host
+     * (e.g. plasmashell, gnome-shell's appindicator
+     * extension, etc.) hands us via ProvideXdgActivationToken right
+     * before it delivers an Activate/menu-click event. Without it,
+     * Wayland compositors refuse to shift focus (focus-stealing
+     * prevention) and only mark the window as demanding attention.
+     */
+    public static void set_activation_token (string token) {
+        _activation_token = token;
+    }
+
+    private static string ? take_activation_token () {
+        var token = _activation_token;
+        _activation_token = null;
+        return token;
+    }
+
+    public static async void launch_app_if_not_running () {
+        var token = take_activation_token ();
+
+        if (yield try_activate_running_instance (token)) {
+            stdout.printf ("[shelly-runner] shelly-ui already running — activated existing window\n");
             return;
         }
 
@@ -28,11 +53,15 @@ public class AppRunner {
         try {
             string[] argv = { "setsid", app_path };
 
+            var envp = Environ.get ();
+            if (token != null)
+                envp = Environ.set_variable (envp, "XDG_ACTIVATION_TOKEN", token, true);
+
             Pid child_pid;
             Process.spawn_async (
                 null,
                 argv,
-                null,
+                envp,
                 SpawnFlags.SEARCH_PATH | SpawnFlags.STDOUT_TO_DEV_NULL | SpawnFlags.STDERR_TO_DEV_NULL,
                 null,
                 out child_pid
@@ -64,17 +93,30 @@ public class AppRunner {
         yield proc.wait_async (null);
     }
 
-    private static bool is_process_running (string name) {
+    /*
+     * Asks a running shelly-ui instance to raise and focus its window via the
+     * org.freedesktop.Application interface that GtkApplication exports on the
+     * session bus. Returns false if no instance owns the name (i.e. not running).
+     *
+     * The token travels as "activation-token" in platform_data; GTK reads it in
+     * gtk_application_impl_wayland_before_emit() and uses it for xdg-activation
+     * when the app calls gtk_window_present().
+     */
+    private static async bool try_activate_running_instance (string? token) {
         try {
-            int exit_status;
-            GLib.Process.spawn_sync (
-                                     null, { "pgrep", "-x", name }, null,
-                                     SpawnFlags.SEARCH_PATH
-                                     | SpawnFlags.STDOUT_TO_DEV_NULL
-                                     | SpawnFlags.STDERR_TO_DEV_NULL,
-                                     null, null, null, out exit_status
-            );
-            return exit_status == 0;
+            var app = yield Bus.get_proxy<FreedesktopApplication> (BusType.SESSION,
+                SHELLY_UI_SERVICE,
+                SHELLY_UI_PATH,
+                DBusProxyFlags.DO_NOT_AUTO_START, null);
+
+            var platform_data = new GLib.HashTable<string, GLib.Variant> (str_hash, str_equal);
+            if (token != null) {
+                platform_data["activation-token"] = new GLib.Variant.string (token);
+                platform_data["desktop-startup-id"] = new GLib.Variant.string (token);
+            }
+
+            yield app.activate (platform_data);
+            return true;
         } catch (Error e) {
             return false;
         }

--- a/Shelly.Notifications/src/dbus_interfaces.vala
+++ b/Shelly.Notifications/src/dbus_interfaces.vala
@@ -15,6 +15,11 @@ public interface FreedesktopStatusNotifierWatcher : Object {
     public abstract bool is_status_notifier_host_registered { owned get; }
 }
 
+[DBus (name = "org.freedesktop.Application")]
+public interface FreedesktopApplication : Object {
+    public abstract async void activate (GLib.HashTable<string, GLib.Variant> platform_data) throws DBusError, IOError;
+}
+
 [DBus (name = "org.freedesktop.Notifications")]
 public interface FreedesktopNotifications : Object {
     public abstract async uint notify (string app_name,
@@ -28,4 +33,5 @@ public interface FreedesktopNotifications : Object {
 
     public signal void action_invoked (uint32 id, string action_key);
     public signal void notification_closed (uint32 id, uint32 reason);
+    public signal void activation_token (uint32 id, string activation_token);
 }

--- a/Shelly.Notifications/src/main.vala
+++ b/Shelly.Notifications/src/main.vala
@@ -33,7 +33,7 @@ public class ShellyApp : Object {
         this.menu_handler = new DBusMenuHandler ((id) => {
             switch (id) {
                 case 1:
-                    AppRunner.launch_app_if_not_running ();
+                    AppRunner.launch_app_if_not_running.begin ();
                     break;
                 case 2:
                     do_update_packages.begin ((obj, res) => {

--- a/Shelly.Notifications/src/notification_handler.vala
+++ b/Shelly.Notifications/src/notification_handler.vala
@@ -47,6 +47,18 @@ public class NotificationHandler : Object {
 
         proxy.action_invoked.connect (handle_action_invoked);
         proxy.notification_closed.connect (handle_notification_closed);
+        proxy.activation_token.connect (handle_activation_token);
+    }
+
+    /*
+     * Emitted by the notification server right before ActionInvoked,
+     * carrying the XDG activation token that lets the raised window
+     * take focus on Wayland.
+     */
+    private void handle_activation_token (uint32 id, string token) {
+        if (notification_ids.contains (id) || recently_closed_notification_ids.contains (id)) {
+            AppRunner.set_activation_token (token);
+        }
     }
 
     private void handle_action_invoked (uint32 id, string action_key) {
@@ -61,7 +73,7 @@ public class NotificationHandler : Object {
             return;
         }
 
-        AppRunner.launch_app_if_not_running ();
+        AppRunner.launch_app_if_not_running.begin ();
     }
 
     private void handle_notification_closed (uint32 id, uint32 reason) {

--- a/Shelly.Notifications/src/tray_item.vala
+++ b/Shelly.Notifications/src/tray_item.vala
@@ -22,7 +22,17 @@ public class StatusNotifierItem : Object {
     public void context_menu (int x, int y) throws DBusError, IOError {}
 
     public void activate (int x, int y) throws DBusError, IOError {
-        AppRunner.launch_app_if_not_running ();
+        AppRunner.launch_app_if_not_running.begin ();
+    }
+
+    /*
+     * On Wayland the tray host (plasmashell, gnome-shell's appindicator
+     * extension, etc.) calls this right before Activate/ContextMenu/menu
+     * events, handing us a fresh XDG activation token so the window we
+     * raise can actually take focus.
+     */
+    public void provide_xdg_activation_token (string token) throws DBusError, IOError {
+        AppRunner.set_activation_token (token);
     }
 
     internal void apply_config (ShellyConfig config) {


### PR DESCRIPTION
Fixes #1298

When shelly-ui was already running the tray click just returned early, so with the window minimized or on another desktop nothing visibly happened. This implements handling via dbus instead of simple process spawning.

The daemon activates the running instance over org.freedesktop.Application.Activate and shelly-ui presents its window. Wayland compositors won't shift focus without an XDG activation token so had to implement some code for that as well.

So now the daemon grabs the one the tray-host/notification hands us via ProvideXdgActivationToken and forwards it. When shelly-ui isn't running it spawns a process just like before, token goes along as XDG_ACTIVATION_TOKEN.

I have tested on KDE Wayland, GNOME Wayland (with tray extension) and XFCE X11 running in VMs and it works fine on all. Window raises, takes focus and switches virtual desktop. On sway+waybar the workspace only flashes urgent and this is becouse waybar tray never provides an activation token (checked the source, same for swaybar) so sway refuses the focus switch, nothing we can fix on our end. Clicking a notification does however function and focus correctly since the notification daemon supplies the token like it shoud.
