### PR TITLE
[Feature]: Granular NoConfirm settings per action type + default-yes prompt

### DIFF
--- a/Shelly.Cli/Commands/AppImage/AppImageRemove.cs
+++ b/Shelly.Cli/Commands/AppImage/AppImageRemove.cs
@@ -8,6 +8,11 @@ namespace Shelly.Cli.Commands.AppImage;
 
 public partial class AppImageRemove : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for appimageremove actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAppImageRemove ?? false || NoConfirm;
+
     public required string AppImage { get; set; }
 
     private bool RemoveConfig { get; set; }
@@ -81,7 +86,7 @@ public partial class AppImageRemove : GlobalSettingsCommand
             return;
         }
 
-        if (NoConfirm &&
+        if (EffectiveNoConfirm &&
             !Confirm.Execute($"Are you sure you want to remove {Path.GetFileName(targetAppImage)}?"))
         {
             return;
@@ -89,7 +94,7 @@ public partial class AppImageRemove : GlobalSettingsCommand
 
         var manager = new AppImageManagerV2(ConfigManager.ReadConfig().AppImageInstallPath ?? "");
         await AppImageSinglePaneOutput.Output(console, manager, x => x.RemoveAppImage(targetAppImage, RemoveConfig),
-            NoConfirm);
+            EffectiveNoConfirm);
     }
 
     public override async ValueTask ExecuteUiMode()

--- a/Shelly.Cli/Commands/AppImage/AppImageUpgrade.cs
+++ b/Shelly.Cli/Commands/AppImage/AppImageUpgrade.cs
@@ -11,6 +11,11 @@ namespace Shelly.Cli.Commands.AppImage;
 
 public partial class AppImageUpgrade : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for appimageupgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAppImageUpgrade ?? false || NoConfirm;
+
     public static Command Create()
     {
         var command = new Command("upgrade", "Upgrades all AppImages");
@@ -49,7 +54,7 @@ public partial class AppImageUpgrade : GlobalSettingsCommand
         {
             console.WriteLine(AnsiUtilities.Colorize($"Updating {update.Name} to {update.Version}",
                 ConsoleColor.Green));
-            await AppImageSinglePaneOutput.Output(console, manager, x => x.RunUpdate(update), NoConfirm);
+            await AppImageSinglePaneOutput.Output(console, manager, x => x.RunUpdate(update), EffectiveNoConfirm);
         }
     }
 

--- a/Shelly.Cli/Commands/Aur/Install.cs
+++ b/Shelly.Cli/Commands/Aur/Install.cs
@@ -7,6 +7,11 @@ namespace Shelly.Cli.Commands.Aur;
 
 public class Install : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for aurinstall actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAurInstall ?? false || NoConfirm;
+
     private bool BuildDeps { get; set; }
 
     private bool MakeDeps { get; set; }
@@ -74,7 +79,7 @@ public class Install : GlobalSettingsCommand
         console.WriteLine(AnsiUtilities.Colorize(
             $"AUR packages to install: {string.Join(", ", packageList)}", ConsoleColor.Yellow));
 
-        if (!NoConfirm && !Confirm.Execute("Do you want to proceed?"))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Do you want to proceed?"))
         {
             console.WriteLine(AnsiUtilities.Colorize("Operation cancelled.", ConsoleColor.Yellow));
             return;
@@ -97,7 +102,7 @@ public class Install : GlobalSettingsCommand
                 ConsoleColor.Yellow));
 
             var depsResult = await AurSinglePaneOutput.Output(console, manager,
-                m => m.InstallDependenciesOnly(packageList.First(), MakeDeps), NoConfirm);
+                m => m.InstallDependenciesOnly(packageList.First(), MakeDeps), EffectiveNoConfirm);
 
             console.WriteLine(depsResult
                 ? AnsiUtilities.Colorize("Dependencies installed successfully!", ConsoleColor.Green)
@@ -109,7 +114,7 @@ public class Install : GlobalSettingsCommand
             $"Installing AUR packages: {string.Join(", ", packageList)}", ConsoleColor.Yellow));
 
         var result = await AurSinglePaneOutput.Output(console, manager,
-            m => m.InstallPackages(packageList), NoConfirm);
+            m => m.InstallPackages(packageList), EffectiveNoConfirm);
 
         console.WriteLine(result
             ? AnsiUtilities.Colorize("Installation complete.", ConsoleColor.Green)
@@ -127,8 +132,8 @@ public class Install : GlobalSettingsCommand
         using var manager = new AurPackageManager();
         await manager.Initialize(root: true, useChroot: UseChroot, noCheck: !Check);
 
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
-        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
+        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         var packageList = Package.ToList();
 

--- a/Shelly.Cli/Commands/Aur/InstallVersion.cs
+++ b/Shelly.Cli/Commands/Aur/InstallVersion.cs
@@ -7,6 +7,11 @@ namespace Shelly.Cli.Commands.Aur;
 
 public class InstallVersion : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for aurinstall actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAurInstall ?? false || NoConfirm;
+
     private bool Check { get; set; }
 
     private string Package { get; set; } = string.Empty;
@@ -72,7 +77,7 @@ public class InstallVersion : GlobalSettingsCommand
             $"Installing AUR package {Package} at commit {Commit}", ConsoleColor.Yellow));
 
         var result = await AurSinglePaneOutput.Output(console, manager,
-            m => m.InstallPackageVersion(Package, Commit), NoConfirm);
+            m => m.InstallPackageVersion(Package, Commit), EffectiveNoConfirm);
 
         console.WriteLine(result
             ? AnsiUtilities.Colorize("Installation complete.", ConsoleColor.Green)
@@ -96,8 +101,8 @@ public class InstallVersion : GlobalSettingsCommand
         using var manager = new AurPackageManager();
         await manager.Initialize(root: true, noCheck: !Check);
 
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
-        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
+        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         UiFrames.TxStart($"Installing AUR package {Package} at commit {Commit}");
         var ok = await UiModeOutput.Run(manager, m => m.InstallPackageVersion(Package, Commit));

--- a/Shelly.Cli/Commands/Aur/Remove.cs
+++ b/Shelly.Cli/Commands/Aur/Remove.cs
@@ -9,6 +9,11 @@ namespace Shelly.Cli.Commands.Aur;
 
 public class Remove : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for aurremove actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAurRemove ?? false || NoConfirm;
+
     private bool Cascade { get; set; }
 
     private bool OptDeps { get; set; }
@@ -84,7 +89,7 @@ public class Remove : GlobalSettingsCommand
         console.WriteLine(AnsiUtilities.Colorize(
             $"Removing AUR packages: {string.Join(", ", packageList)}", ConsoleColor.Yellow));
 
-        if (!NoConfirm && !Confirm.Execute("Do you want to proceed?"))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Do you want to proceed?"))
         {
             console.WriteLine(AnsiUtilities.Colorize("Operation cancelled.", ConsoleColor.Yellow));
             return;
@@ -94,7 +99,7 @@ public class Remove : GlobalSettingsCommand
         await manager.Initialize(root: true);
 
         var result = await AurSinglePaneOutput.Output(console, manager,
-            m => m.RemovePackages(packageList, BuildFlags(), OptDeps), NoConfirm);
+            m => m.RemovePackages(packageList, BuildFlags(), OptDeps), EffectiveNoConfirm);
 
         console.WriteLine(result
             ? AnsiUtilities.Colorize("Removal complete.", ConsoleColor.Green)
@@ -112,8 +117,8 @@ public class Remove : GlobalSettingsCommand
         using var manager = new AurPackageManager();
         await manager.Initialize(root: true);
 
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
-        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
+        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         var packageList = Package.ToList();
         UiFrames.TxStart($"Removing AUR packages: {string.Join(", ", packageList)}");

--- a/Shelly.Cli/Commands/Aur/Update.cs
+++ b/Shelly.Cli/Commands/Aur/Update.cs
@@ -7,6 +7,11 @@ namespace Shelly.Cli.Commands.Aur;
 
 public class Update : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for aurupgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAurUpgrade ?? false || NoConfirm;
+
     private bool Check { get; set; }
 
     private string[] Package { get; set; } = Array.Empty<string>();
@@ -56,7 +61,7 @@ public class Update : GlobalSettingsCommand
 
         var packageList = Package.ToList();
 
-        if (!NoConfirm && !Confirm.Execute($"Proceed with update for {string.Join(", ", packageList)}?", true))
+        if (!EffectiveNoConfirm && !Confirm.Execute($"Proceed with update for {string.Join(", ", packageList)}?", true))
         {
             console.WriteLine(AnsiUtilities.Colorize("Update cancelled.", ConsoleColor.Yellow));
             return;
@@ -66,7 +71,7 @@ public class Update : GlobalSettingsCommand
         await manager.Initialize(root: true, noCheck: !Check);
 
         var result = await AurSinglePaneOutput.Output(console, manager,
-            m => m.UpdatePackages(packageList), NoConfirm);
+            m => m.UpdatePackages(packageList), EffectiveNoConfirm);
 
         console.WriteLine(result
             ? AnsiUtilities.Colorize("Update complete.", ConsoleColor.Green)
@@ -84,8 +89,8 @@ public class Update : GlobalSettingsCommand
         using var manager = new AurPackageManager();
         await manager.Initialize(root: true, noCheck: !Check);
 
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
-        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
+        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         var packageList = Package.ToList();
         UiFrames.TxStart($"Updating AUR packages: {string.Join(", ", packageList)}");

--- a/Shelly.Cli/Commands/Aur/Upgrade.cs
+++ b/Shelly.Cli/Commands/Aur/Upgrade.cs
@@ -10,6 +10,11 @@ namespace Shelly.Cli.Commands.Aur;
 
 public class Upgrade : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for aurupgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmAurUpgrade ?? false || NoConfirm;
+
     private static readonly Option<bool> CheckOption =
         new("--check") { Description = "Run the check() function during AUR package builds (disabled by default)" };
 
@@ -65,7 +70,7 @@ public class Upgrade : GlobalSettingsCommand
         foreach (var pkg in updates)
             console.WriteLine($"  {pkg.Name}: {pkg.Version} -> {pkg.NewVersion}");
 
-        if (!NoConfirm && !Confirm.Execute("Proceed with upgrade?", false))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Proceed with upgrade?", DefaultYes))
         {
             console.WriteLine(Color("Upgrade cancelled.", ConsoleColor.Red));
             return;
@@ -73,7 +78,7 @@ public class Upgrade : GlobalSettingsCommand
 
         var packageNames = updates.Select(u => u.Name).ToList();
         var result = await AurSinglePaneOutput.Output(
-            console, manager, m => m.UpdatePackages(packageNames), NoConfirm);
+            console, manager, m => m.UpdatePackages(packageNames), EffectiveNoConfirm);
 
         console.WriteLine(result
             ? Color("Upgrade complete.", ConsoleColor.Green)
@@ -92,8 +97,8 @@ public class Upgrade : GlobalSettingsCommand
             return;
         }
 
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
-        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
+        manager.PkgbuildDiffRequest += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         JsonPackFrame.WriteToStdout<Event>(new AlpmInformationalEvent(
             AlpmEvents.AurDownloadStart,

--- a/Shelly.Cli/Commands/Flatpak/Install.cs
+++ b/Shelly.Cli/Commands/Flatpak/Install.cs
@@ -9,6 +9,11 @@ namespace Shelly.Cli.Commands.Flatpak;
 
 public class Install : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for flatpakinstall actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmFlatpakInstall ?? false || NoConfirm;
+
     private string Package { get; set; } = string.Empty;
     private bool IsUser { get; set; }
     private string? Remote { get; set; }
@@ -107,7 +112,7 @@ public class Install : GlobalSettingsCommand
 
         await FlatpakSinglePaneOutput.Output(console, manager,
             x => x.InstallApp(packageToInstall, IsUser ? InstallLevel.User : InstallLevel.System, Branch ?? "stable",
-                remoteToUse, IsRuntime), NoConfirm);
+                remoteToUse, IsRuntime), EffectiveNoConfirm);
     }
 
     public override async ValueTask ExecuteUiMode()

--- a/Shelly.Cli/Commands/Flatpak/InstallBundle.cs
+++ b/Shelly.Cli/Commands/Flatpak/InstallBundle.cs
@@ -8,6 +8,11 @@ namespace Shelly.Cli.Commands.Flatpak;
 
 public class InstallBundle : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for flatpakinstall actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmFlatpakInstall ?? false || NoConfirm;
+
     private string BundlePath { get; set; } = string.Empty;
     private bool SystemWide { get; set; }
 
@@ -48,7 +53,7 @@ public class InstallBundle : GlobalSettingsCommand
         console.WriteLine(Colorize("Installing flatpak bundle...", ConsoleColor.Yellow));
         var manager = new FlatpakManager();
         await FlatpakSinglePaneOutput.Output(console, manager,
-            x => x.InstallAppFromBundle(BundlePath, SystemWide ? InstallLevel.System : InstallLevel.User), NoConfirm);
+            x => x.InstallAppFromBundle(BundlePath, SystemWide ? InstallLevel.System : InstallLevel.User), EffectiveNoConfirm);
     }
 
     public override async ValueTask ExecuteUiMode()

--- a/Shelly.Cli/Commands/Flatpak/Upgrade.cs
+++ b/Shelly.Cli/Commands/Flatpak/Upgrade.cs
@@ -8,6 +8,11 @@ namespace Shelly.Cli.Commands.Flatpak;
 
 public class Upgrade : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for flatpakupgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmFlatpakUpgrade ?? false || NoConfirm;
+
     public static Command Create()
     {
         var command = new Command("upgrade", "Upgrade all flatpak apps");
@@ -46,13 +51,13 @@ public class Upgrade : GlobalSettingsCommand
         if (packages.Any(x => x.InstallLevel == InstallLevel.User))
         {
             await FlatpakSinglePaneOutput.Output(console, manager,
-                x => x.UpdateAllUserFlatpak(), NoConfirm);
+                x => x.UpdateAllUserFlatpak(), EffectiveNoConfirm);
         }
 
         if (packages.Any(x => x.InstallLevel == InstallLevel.System))
         {
             await FlatpakSinglePaneOutput.Output(console, manager,
-                x => x.UpdateAllSystemFlatpak(), NoConfirm);
+                x => x.UpdateAllSystemFlatpak(), EffectiveNoConfirm);
         }
     }
 

--- a/Shelly.Cli/Commands/GlobalOptions.cs
+++ b/Shelly.Cli/Commands/GlobalOptions.cs
@@ -5,7 +5,7 @@ namespace Shelly.Cli.Commands;
 internal static class GlobalOptions
 {
     public static readonly Option<bool> NoConfirm =
-        new("--no-confirm", "-n") { Description = "Disable confirmation prompts", Recursive = true };
+        new("--no-confirm", "-n") { Description = "Disable confirmation prompts for all actions", Recursive = true };
 
     public static readonly Option<bool> UiMode =
         new("--ui-mode", "-U") { Description = "Enable UI mode", Recursive = true };
@@ -16,12 +16,69 @@ internal static class GlobalOptions
     public static readonly Option<bool> Verbose =
         new("--verbose", "-v") { Description = "Enable verbose logging.", Recursive = true };
 
+    // Per-action no-confirm flags
+    public static readonly Option<bool> NoConfirmUpgrade =
+        new("--no-confirm-upgrade") { Description = "Skip confirmation for upgrade actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmInstall =
+        new("--no-confirm-install") { Description = "Skip confirmation for install actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmRemove =
+        new("--no-confirm-remove") { Description = "Skip confirmation for remove actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmDowngrade =
+        new("--no-confirm-downgrade") { Description = "Skip confirmation for downgrade actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmAurInstall =
+        new("--no-confirm-aur-install") { Description = "Skip confirmation for AUR install actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmAurRemove =
+        new("--no-confirm-aur-remove") { Description = "Skip confirmation for AUR remove actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmAurUpgrade =
+        new("--no-confirm-aur-upgrade") { Description = "Skip confirmation for AUR upgrade actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmFlatpakInstall =
+        new("--no-confirm-flatpak-install") { Description = "Skip confirmation for Flatpak install actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmFlatpakRemove =
+        new("--no-confirm-flatpak-remove") { Description = "Skip confirmation for Flatpak remove actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmFlatpakUpgrade =
+        new("--no-confirm-flatpak-upgrade") { Description = "Skip confirmation for Flatpak upgrade actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmAppImageRemove =
+        new("--no-confirm-appimage-remove") { Description = "Skip confirmation for AppImage remove actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmAppImageUpgrade =
+        new("--no-confirm-appimage-upgrade") { Description = "Skip confirmation for AppImage upgrade actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmPurify =
+        new("--no-confirm-purify") { Description = "Skip confirmation for purify actions", Recursive = true };
+
+    public static readonly Option<bool> NoConfirmMark =
+        new("--no-confirm-mark") { Description = "Skip confirmation for mark actions", Recursive = true };
+
     public static void AddToRoot(RootCommand root)
     {
         root.Add(NoConfirm);
         root.Add(UiMode);
         root.Add(Json);
         root.Add(Verbose);
+        root.Add(NoConfirmUpgrade);
+        root.Add(NoConfirmInstall);
+        root.Add(NoConfirmRemove);
+        root.Add(NoConfirmDowngrade);
+        root.Add(NoConfirmAurInstall);
+        root.Add(NoConfirmAurRemove);
+        root.Add(NoConfirmAurUpgrade);
+        root.Add(NoConfirmFlatpakInstall);
+        root.Add(NoConfirmFlatpakRemove);
+        root.Add(NoConfirmFlatpakUpgrade);
+        root.Add(NoConfirmAppImageRemove);
+        root.Add(NoConfirmAppImageUpgrade);
+        root.Add(NoConfirmPurify);
+        root.Add(NoConfirmMark);
     }
 
     public static void Apply(GlobalSettingsCommand command, ParseResult parseResult)
@@ -30,5 +87,19 @@ internal static class GlobalOptions
         command.UiMode = parseResult.GetValue(UiMode);
         command.JsonOutput = parseResult.GetValue(Json);
         command.Verbose = parseResult.GetValue(Verbose);
+        command.NoConfirmUpgrade = parseResult.GetValue(NoConfirmUpgrade);
+        command.NoConfirmInstall = parseResult.GetValue(NoConfirmInstall);
+        command.NoConfirmRemove = parseResult.GetValue(NoConfirmRemove);
+        command.NoConfirmDowngrade = parseResult.GetValue(NoConfirmDowngrade);
+        command.NoConfirmAurInstall = parseResult.GetValue(NoConfirmAurInstall);
+        command.NoConfirmAurRemove = parseResult.GetValue(NoConfirmAurRemove);
+        command.NoConfirmAurUpgrade = parseResult.GetValue(NoConfirmAurUpgrade);
+        command.NoConfirmFlatpakInstall = parseResult.GetValue(NoConfirmFlatpakInstall);
+        command.NoConfirmFlatpakRemove = parseResult.GetValue(NoConfirmFlatpakRemove);
+        command.NoConfirmFlatpakUpgrade = parseResult.GetValue(NoConfirmFlatpakUpgrade);
+        command.NoConfirmAppImageRemove = parseResult.GetValue(NoConfirmAppImageRemove);
+        command.NoConfirmAppImageUpgrade = parseResult.GetValue(NoConfirmAppImageUpgrade);
+        command.NoConfirmPurify = parseResult.GetValue(NoConfirmPurify);
+        command.NoConfirmMark = parseResult.GetValue(NoConfirmMark);
     }
 }

--- a/Shelly.Cli/Commands/GlobalSettingsCommand.cs
+++ b/Shelly.Cli/Commands/GlobalSettingsCommand.cs
@@ -2,13 +2,51 @@ namespace Shelly.Cli.Commands;
 
 public abstract class GlobalSettingsCommand
 {
+    /// <summary>
+    /// Legacy global no-confirm flag (--no-confirm / -n). When true, all actions skip confirmation.
+    /// </summary>
     public bool NoConfirm { get; set; }
+
+    /// <summary>
+    /// Per-action no-confirm overrides set via --no-confirm-* flags.
+    /// </summary>
+    public bool? NoConfirmUpgrade { get; set; }
+    public bool? NoConfirmInstall { get; set; }
+    public bool? NoConfirmRemove { get; set; }
+    public bool? NoConfirmDowngrade { get; set; }
+    public bool? NoConfirmAurInstall { get; set; }
+    public bool? NoConfirmAurRemove { get; set; }
+    public bool? NoConfirmAurUpgrade { get; set; }
+    public bool? NoConfirmFlatpakInstall { get; set; }
+    public bool? NoConfirmFlatpakRemove { get; set; }
+    public bool? NoConfirmFlatpakUpgrade { get; set; }
+    public bool? NoConfirmAppImageRemove { get; set; }
+    public bool? NoConfirmAppImageUpgrade { get; set; }
+    public bool? NoConfirmPurify { get; set; }
+    public bool? NoConfirmMark { get; set; }
 
     public bool UiMode { get; set; }
 
     public bool JsonOutput { get; set; }
 
     public bool Verbose { get; set; }
+
+    /// <summary>
+    /// Resolves the effective no-confirm value for a given action.
+    /// Priority: per-action CLI flag > per-action config > global CLI flag > global config All
+    /// </summary>
+    protected bool ShouldSkipConfirm(bool actionSpecificConfig)
+    {
+        // Global CLI flag overrides everything
+        if (NoConfirm) return true;
+        return actionSpecificConfig;
+    }
+
+    /// <summary>
+    /// Resolves the default-yes prompt setting from config.
+    /// When true, prompts show Y/n (yes by default) instead of y/N.
+    /// </summary>
+    protected bool DefaultYes => ConfigManager.ReadConfig().NoConfirmSettings.DefaultYesPrompt;
 
     public abstract ValueTask ExecuteAsync(IShellyConsole console);
 

--- a/Shelly.Cli/Commands/Standard/DowngradePackage.cs
+++ b/Shelly.Cli/Commands/Standard/DowngradePackage.cs
@@ -17,6 +17,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public partial class DowngradePackage : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for downgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmDowngrade ?? false || NoConfirm;
+
     private const string ArchRepo = "https://archive.archlinux.org/packages/";
     private const string CachyosRepo = "https://archive.cachyos.org/archive/cachyos/";
     private const string CachyosV3Repo = "https://archive.cachyos.org/archive/cachyos-v3/";
@@ -134,7 +139,7 @@ public partial class DowngradePackage : GlobalSettingsCommand
         }
 
         PackageInfo selectedPackage;
-        if (NoConfirm || UseOldest)
+        if (EffectiveNoConfirm || UseOldest)
         {
             selectedPackage = UseOldest ? packages[^1] : packages[0];
         }
@@ -161,7 +166,7 @@ public partial class DowngradePackage : GlobalSettingsCommand
         var path = await ResolveFilePathCli(selectedPackage, console);
         if (path == null) return;
 
-        if (!NoConfirm && !Confirm.Execute("Do you want to proceed with the installation?"))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Do you want to proceed with the installation?"))
         {
             console.WriteLine(Colorize("Operation Cancelled.", ConsoleColor.Yellow));
             return;
@@ -170,7 +175,7 @@ public partial class DowngradePackage : GlobalSettingsCommand
         console.WriteLine(Colorize($"Installing: {selectedPackage.Filename}", ConsoleColor.Green));
 
         var isSuccess =
-            await StandardSinglePaneOutput.Output(console, manager, m => m.InstallLocalPackage(path), NoConfirm);
+            await StandardSinglePaneOutput.Output(console, manager, m => m.InstallLocalPackage(path), EffectiveNoConfirm);
 
         if (selectedPackage.Location == Location.Remote && File.Exists(path))
             try
@@ -189,7 +194,7 @@ public partial class DowngradePackage : GlobalSettingsCommand
             return;
         }
 
-        if (AddIgnore || (!NoConfirm && Confirm.Execute("Do you want to add package to IgnorePkg list?")))
+        if (AddIgnore || (!EffectiveNoConfirm && Confirm.Execute("Do you want to add package to IgnorePkg list?")))
         {
             console.WriteLine(Colorize($"Adding to IgnorePkg: {Package}", ConsoleColor.Green));
             try

--- a/Shelly.Cli/Commands/Standard/Install.cs
+++ b/Shelly.Cli/Commands/Standard/Install.cs
@@ -14,6 +14,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class Install : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for install actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmInstall ?? false || NoConfirm;
+
     private bool BuildDeps { get; set; }
 
     private bool MakeDeps { get; set; }
@@ -104,7 +109,7 @@ public class Install : GlobalSettingsCommand
     {
         console.WriteLine(Colorize($"Packages to install: {string.Join(", ", packageList)}", ConsoleColor.Yellow));
 
-        if (!NoConfirm && !Confirm.Execute("Do you want to proceed?"))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Do you want to proceed?"))
         {
             console.WriteLine(Colorize("Operation cancelled.", ConsoleColor.Yellow));
             return;
@@ -184,7 +189,7 @@ public class Install : GlobalSettingsCommand
 
         Task<bool> RunOutput(Func<IAlpmManager, Task<bool>> op)
         {
-            return StandardSinglePaneOutput.Output(console, manager, op, NoConfirm);
+            return StandardSinglePaneOutput.Output(console, manager, op, EffectiveNoConfirm);
         }
     }
 
@@ -202,7 +207,7 @@ public class Install : GlobalSettingsCommand
             console.WriteLine(Colorize("Initializing ALPM...", ConsoleColor.Yellow));
             manager.Initialize();
             var result = await StandardSinglePaneOutput.Output(console, manager,
-                x => x.InstallLocalPackage(Path.GetFullPath(location)), NoConfirm);
+                x => x.InstallLocalPackage(Path.GetFullPath(location)), EffectiveNoConfirm);
             if (!result)
                 console.WriteLine(Colorize("Installation failed. See errors above.", ConsoleColor.Red));
             return;
@@ -269,7 +274,7 @@ public class Install : GlobalSettingsCommand
     {
         using var manager = new AlpmManager();
         manager.Initialize(true);
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         if (Upgrade)
         {
@@ -324,7 +329,7 @@ public class Install : GlobalSettingsCommand
         if (await FileInspector.IsArchPackage(location))
         {
             using var manager = new AlpmManager();
-            manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+            manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
             manager.Initialize();
 
             UiFrames.TxStart($"Installing local package: {location}");

--- a/Shelly.Cli/Commands/Standard/Mark.cs
+++ b/Shelly.Cli/Commands/Standard/Mark.cs
@@ -8,6 +8,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class Mark : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for mark actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmMark ?? false || NoConfirm;
+
     private bool Explicit { get; set; }
 
     private bool Depends { get; set; }
@@ -57,7 +62,7 @@ public class Mark : GlobalSettingsCommand
 
         RootElevator.EnsureRootExectuion();
 
-        if (!NoConfirm && !Confirm.Execute("Do you want to proceed with the operation?"))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Do you want to proceed with the operation?"))
         {
             console.WriteLine(Colorize("Operation Cancelled.", ConsoleColor.Yellow));
             return;

--- a/Shelly.Cli/Commands/Standard/PurifyPackages.cs
+++ b/Shelly.Cli/Commands/Standard/PurifyPackages.cs
@@ -8,6 +8,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class PurifyPackages : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for purify actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmPurify ?? false || NoConfirm;
+
     private bool DryRun { get; set; }
 
     private bool Orphans { get; set; }
@@ -43,7 +48,7 @@ public class PurifyPackages : GlobalSettingsCommand
         RootElevator.EnsureRootExectuion();
 
 
-        if (!NoConfirm && !DryRun && !Confirm.Execute("Do you want to proceed with the operation?"))
+        if (!EffectiveNoConfirm && !DryRun && !Confirm.Execute("Do you want to proceed with the operation?"))
         {
             console.WriteLine(Colorize("Operation Cancelled.", ConsoleColor.Yellow));
             return;

--- a/Shelly.Cli/Commands/Standard/Remove.cs
+++ b/Shelly.Cli/Commands/Standard/Remove.cs
@@ -11,6 +11,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class Remove : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for remove actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmRemove ?? false || NoConfirm;
+
     private bool Cascade { get; set; }
 
     private bool OptDeps { get; set; }
@@ -100,7 +105,7 @@ public class Remove : GlobalSettingsCommand
 
         console.WriteLine(Colorize($"Packages to remove: {string.Join(", ", Packages)}", ConsoleColor.Yellow));
 
-        if (!NoConfirm && !Confirm.Execute("Do you want to proceed?"))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Do you want to proceed?"))
         {
             console.WriteLine(Colorize("Operation cancelled.", ConsoleColor.Yellow));
             return;
@@ -159,7 +164,7 @@ public class Remove : GlobalSettingsCommand
         }
 
         var result = await StandardSinglePaneOutput.Output(console, manager,
-            x => x.RemovePackages(packages, flags, OptDeps), NoConfirm);
+            x => x.RemovePackages(packages, flags, OptDeps), EffectiveNoConfirm);
 
         if (!result)
         {
@@ -218,7 +223,7 @@ public class Remove : GlobalSettingsCommand
             flags |= AlpmTransFlag.Cascade;
 
         using var manager = new AlpmManager();
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
         manager.Initialize(true);
 
         UiFrames.TxStart($"Removing packages: {string.Join(", ", packages)}");

--- a/Shelly.Cli/Commands/Standard/Sync.cs
+++ b/Shelly.Cli/Commands/Standard/Sync.cs
@@ -7,6 +7,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class Sync : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for upgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmUpgrade ?? false || NoConfirm;
+
     private bool Force { get; set; }
 
     public static Command Create()
@@ -47,7 +52,7 @@ public class Sync : GlobalSettingsCommand
             {
                 m.Sync(Force);
                 return Task.FromResult(true);
-            }, NoConfirm);
+            }, EffectiveNoConfirm);
 
         console.WriteLine(result
             ? Colorize("Package databases synchronized successfully!", ConsoleColor.Green)
@@ -57,7 +62,7 @@ public class Sync : GlobalSettingsCommand
     public override async ValueTask ExecuteUiMode()
     {
         using var manager = new AlpmManager();
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
         manager.Initialize(true);
 
         UiFrames.TxStart("Synchronizing package databases...");

--- a/Shelly.Cli/Commands/Standard/Update.cs
+++ b/Shelly.Cli/Commands/Standard/Update.cs
@@ -9,6 +9,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class Update : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for upgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmUpgrade ?? false || NoConfirm;
+
     private string[] Packages { get; set; } = [];
 
     public static Command Create()
@@ -49,7 +54,7 @@ public class Update : GlobalSettingsCommand
 
         console.WriteLine(Colorize($"Packages to update: {string.Join(", ", Packages)}", ConsoleColor.Yellow));
 
-        if (!NoConfirm)
+        if (!EffectiveNoConfirm)
         {
             console.WriteLine(Colorize(
                 "WARNING: Updating individual packages is a partial upgrade and is strongly discouraged on Arch Linux.",
@@ -71,7 +76,7 @@ public class Update : GlobalSettingsCommand
         manager.IntializeWithSync();
 
         console.WriteLine(Colorize("Updating packages...", ConsoleColor.Yellow));
-        var result = await StandardSinglePaneOutput.Output(console, manager, m => m.UpdatePackages(Packages.ToList()), NoConfirm);
+        var result = await StandardSinglePaneOutput.Output(console, manager, m => m.UpdatePackages(Packages.ToList()), EffectiveNoConfirm);
 
         console.WriteLine(result
             ? Colorize("Packages updated successfully!", ConsoleColor.Green)
@@ -87,7 +92,7 @@ public class Update : GlobalSettingsCommand
         }
 
         using var manager = new AlpmManager();
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
         manager.IntializeWithSync();
 
         UiFrames.TxStart($"Updating packages: {string.Join(", ", Packages)}");

--- a/Shelly.Cli/Commands/Standard/Upgrade.cs
+++ b/Shelly.Cli/Commands/Standard/Upgrade.cs
@@ -12,6 +12,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class Upgrade : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for upgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmUpgrade ?? false || NoConfirm;
+
     public static Command Create()
     {
         var command = new Command("upgrade", "Perform a full system upgrade");
@@ -71,14 +76,14 @@ public class Upgrade : GlobalSettingsCommand
         console.WriteLine(Colorize($"Net Upgrade Size: {upgradeSize}", ConsoleColor.DarkGreen));
         console.WriteLine();
 
-        if (!NoConfirm && !Confirm.Execute("Proceed with upgrade?", false))
+        if (!EffectiveNoConfirm && !Confirm.Execute("Proceed with upgrade?", DefaultYes))
         {
             console.WriteLine(Colorize("Upgrade cancelled.", ConsoleColor.Red));
             return;
         }
 
         console.WriteLine(Colorize("Starting System Upgrade...", ConsoleColor.Green));
-        var upgradeResult = await StandardSinglePaneOutput.Output(console, manager, x => x.SyncSystemUpdate(), NoConfirm);
+        var upgradeResult = await StandardSinglePaneOutput.Output(console, manager, x => x.SyncSystemUpdate(), EffectiveNoConfirm);
         manager.Dispose();
 
         console.WriteLine(upgradeResult
@@ -91,7 +96,7 @@ public class Upgrade : GlobalSettingsCommand
         UiFrames.Info("Performing full system upgrade...");
 
         using var manager = new AlpmManager();
-        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, NoConfirm);
+        manager.Question += (_, args) => QuestionHandler.HandleQuestion(args, true, EffectiveNoConfirm);
 
         UiFrames.Info("Initializing and syncing repositories...");
         manager.IntializeWithSync();

--- a/Shelly.Cli/Commands/Standard/UpgradeAll.cs
+++ b/Shelly.Cli/Commands/Standard/UpgradeAll.cs
@@ -23,6 +23,11 @@ namespace Shelly.Cli.Commands.Standard;
 
 public class UpgradeAll : GlobalSettingsCommand
 {
+    /// <summary>
+    /// Resolved no-confirm for upgrade actions: per-action flag OR global flag.
+    /// </summary>
+    private bool EffectiveNoConfirm => NoConfirmUpgrade ?? false || NoConfirm;
+
     private static readonly Option<bool> NoRepoOption =
         new("--no-repo") { Description = "Skip the standard repository (ALPM) upgrade" };
 
@@ -93,7 +98,7 @@ public class UpgradeAll : GlobalSettingsCommand
 
             RenderPlan(console, plan);
 
-            if (!NoConfirm && !Confirm.Execute("Proceed with all upgrades?", false))
+            if (!EffectiveNoConfirm && !Confirm.Execute("Proceed with all upgrades?", DefaultYes))
             {
                 console.WriteLine(Colorize("Upgrade cancelled.", ConsoleColor.Red));
                 return;
@@ -351,7 +356,7 @@ public class UpgradeAll : GlobalSettingsCommand
     private List<string> BuildFlatpakArgs()
     {
         var args = new List<string> { "flatpak", "upgrade" };
-        if (NoConfirm)
+        if (EffectiveNoConfirm)
             args.Add("--no-confirm");
         if (JsonOutput)
             args.Add("--json");
@@ -362,7 +367,7 @@ public class UpgradeAll : GlobalSettingsCommand
 
     private async ValueTask RunChild(GlobalSettingsCommand child, IShellyConsole? console, bool isStandardUpgrade = false)
     {
-        child.NoConfirm = NoConfirm || isStandardUpgrade;
+        child.EffectiveNoConfirm = EffectiveNoConfirm || isStandardUpgrade;
         child.UiMode = UiMode;
         child.JsonOutput = JsonOutput;
         child.Verbose = Verbose;

--- a/Shelly.Cli/ConfigManager.cs
+++ b/Shelly.Cli/ConfigManager.cs
@@ -152,6 +152,10 @@ public static class ConfigManager
                         .ToList();
                 }
             }
+            else if (targetType == typeof(NoConfirmSettings))
+            {
+                convertedValue = JsonSerializer.Deserialize<NoConfirmSettings>(value) ?? new NoConfirmSettings();
+            }
             else if (targetType.IsEnum)
             {
                 if (!Enum.TryParse(targetType, value, true, out convertedValue))
@@ -329,9 +333,45 @@ public static class ConfigManager
                 config.TrayCheckIntervalHours = interval.GetInt32();
             }
 
-            if (root.TryGetProperty("NoConfirm", out var noConfirm))
+            if (root.TryGetProperty("NoConfirmSettings", out var noConfirmSettings) && noConfirmSettings.ValueKind == JsonValueKind.Object)
             {
-                config.NoConfirm = noConfirm.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("All", out var all))
+                    config.NoConfirmSettings.All = all.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("Upgrade", out var upgrade))
+                    config.NoConfirmSettings.Upgrade = upgrade.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("Install", out var install))
+                    config.NoConfirmSettings.Install = install.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("Remove", out var remove))
+                    config.NoConfirmSettings.Remove = remove.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("Downgrade", out var downgrade))
+                    config.NoConfirmSettings.Downgrade = downgrade.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("AurInstall", out var aurInstall))
+                    config.NoConfirmSettings.AurInstall = aurInstall.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("AurRemove", out var aurRemove))
+                    config.NoConfirmSettings.AurRemove = aurRemove.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("AurUpgrade", out var aurUpgrade))
+                    config.NoConfirmSettings.AurUpgrade = aurUpgrade.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("FlatpakInstall", out var flatpakInstall))
+                    config.NoConfirmSettings.FlatpakInstall = flatpakInstall.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("FlatpakRemove", out var flatpakRemove))
+                    config.NoConfirmSettings.FlatpakRemove = flatpakRemove.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("FlatpakUpgrade", out var flatpakUpgrade))
+                    config.NoConfirmSettings.FlatpakUpgrade = flatpakUpgrade.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("AppImageRemove", out var appImageRemove))
+                    config.NoConfirmSettings.AppImageRemove = appImageRemove.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("AppImageUpgrade", out var appImageUpgrade))
+                    config.NoConfirmSettings.AppImageUpgrade = appImageUpgrade.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("Purify", out var purify))
+                    config.NoConfirmSettings.Purify = purify.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("Mark", out var mark))
+                    config.NoConfirmSettings.Mark = mark.GetBoolean();
+                if (noConfirmSettings.TryGetProperty("DefaultYesPrompt", out var defaultYes))
+                    config.NoConfirmSettings.DefaultYesPrompt = defaultYes.GetBoolean();
+            }
+            else if (root.TryGetProperty("NoConfirm", out var noConfirm))
+            {
+                // Backward compatibility: old single bool maps to All
+                config.NoConfirmSettings.All = noConfirm.GetBoolean();
             }
 
             if (root.TryGetProperty("NewInstall", out var newInstall))

--- a/Shelly.Gtk/Program.cs
+++ b/Shelly.Gtk/Program.cs
@@ -853,7 +853,7 @@ sealed class Program
                         return;
                     }
 
-                    if (!configService.LoadConfig().NoConfirm)
+                    if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.Upgrade))
                     {
                         var confirmArgs = new GenericQuestionEventArgs(
                             "Upgrade All Packages?",

--- a/Shelly.Gtk/Services/ConfigService.cs
+++ b/Shelly.Gtk/Services/ConfigService.cs
@@ -46,7 +46,9 @@ public class ConfigService : IConfigService
         CallCliConfigSet(nameof(config.UseOldMenu), config.UseOldMenu.ToString());
         CallCliConfigSet(nameof(config.TrayEnabled), config.TrayEnabled.ToString());
         CallCliConfigSet(nameof(config.TrayCheckIntervalHours), config.TrayCheckIntervalHours.ToString());
-        CallCliConfigSet(nameof(config.NoConfirm), config.NoConfirm.ToString());
+        // NoConfirmSettings - save as a JSON object via a single config key
+        var noConfirmJson = System.Text.Json.JsonSerializer.Serialize(config.NoConfirmSettings);
+        CallCliConfigSet("NoConfirmSettings", noConfirmJson);
         CallCliConfigSet(nameof(config.NewInstall), config.NewInstall.ToString());
         CallCliConfigSet(nameof(config.CurrentVersion), config.CurrentVersion);
         CallCliConfigSet(nameof(config.UseWeeklySchedule), config.UseWeeklySchedule.ToString());

--- a/Shelly.Gtk/Services/PrivilegedOperationService.cs
+++ b/Shelly.Gtk/Services/PrivilegedOperationService.cs
@@ -12,7 +12,7 @@ public class PrivilegedOperationService(
     IPackageUpdateNotifier packageUpdateNotifier,
     IDirtyService dirtyService) : IPrivilegedOperationService
 {
-    private readonly bool _noConfirm = configService.LoadConfig().NoConfirm;
+    private NoConfirmSettings NoConfirmSettings => configService.LoadConfig().NoConfirmSettings;
 
     public async Task<OperationResult> SyncDatabasesAsync()
     {
@@ -25,7 +25,7 @@ public class PrivilegedOperationService(
         var args = new List<string> { "install" };
         args.AddRange(packages);
         if (upgrade) args.Add("-u");
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Install)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Install packages", args.ToArray());
         if (result.Success) dirtyService.MarkDirty(DirtyScopes.Native);
@@ -35,7 +35,7 @@ public class PrivilegedOperationService(
     public async Task<OperationResult> InstallLocalPackageAsync(string filePath)
     {
         var args = new List<string> { "install", filePath };
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Install)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Install local package", args.ToArray());
         if (result.Success) dirtyService.MarkDirty(DirtyScopes.Native);
@@ -50,7 +50,7 @@ public class PrivilegedOperationService(
         args.Add($"-c={isCascade}");
         if (isCleanup) args.Add("-r");
         if (removeOptionalDeps) args.Add("-o");
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Remove)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Remove packages", args.ToArray());
         if (result.Success && removePackageFromCache) _ = await RemovePackageCacheAsync(packages);
@@ -62,7 +62,7 @@ public class PrivilegedOperationService(
     {
         var args = new List<string> { "remove" };
         args.AddRange(packages);
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Remove)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Remove local packages", args.ToArray());
         if (result.Success) dirtyService.MarkDirty(DirtyScopes.Native);
@@ -73,7 +73,7 @@ public class PrivilegedOperationService(
     {
         var args = new List<string> { "update" };
         args.AddRange(packages);
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Upgrade)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Update packages", args.ToArray());
         SendDbusMessage(result);
@@ -84,7 +84,7 @@ public class PrivilegedOperationService(
     public async Task<OperationResult> UpgradeSystemAsync()
     {
         var args = new List<string> { "upgrade" };
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Upgrade)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Upgrade system", args.ToArray());
         SendDbusMessage(result);
@@ -94,7 +94,7 @@ public class PrivilegedOperationService(
     public async Task<OperationResult> UpgradeAllAsync()
     {
         var args = new List<string> { "upgrade-all" };
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.Upgrade)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Upgrade all", args.ToArray());
         if (!result.Success) _ = Task.Run(trayDbus.UpdatesMadeInUiAsync);
@@ -121,7 +121,7 @@ public class PrivilegedOperationService(
         args.AddRange(packages);
         if (useChroot) args.Add("-c");
         if (runChecks) args.Add("--check");
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.AurInstall)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Install AUR packages", args.ToArray());
         if (result.Success) dirtyService.MarkDirty(DirtyScopes.Aur);
@@ -133,7 +133,7 @@ public class PrivilegedOperationService(
         var args = new List<string> { "aur", "remove" };
         args.AddRange(packages);
         args.Add($"-c={isCascade}");
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.AurRemove)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Remove AUR packages", args.ToArray());
         if (result.Success) dirtyService.MarkDirty(DirtyScopes.Aur);
@@ -145,7 +145,7 @@ public class PrivilegedOperationService(
         var args = new List<string> { "aur", "update" };
         args.AddRange(packages);
         if (runChecks) args.Add("--check");
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.AurUpgrade)) args.Add("--no-confirm");
 
         var result = await processExecutor.RunPrivilegedShellyCommandAsync("Update AUR packages", args.ToArray());
         SendDbusMessage(result);
@@ -157,7 +157,7 @@ public class PrivilegedOperationService(
     {
         var args = new List<string> { "aur", "search-pkgbuild" };
         args.AddRange(packages);
-        if (_noConfirm) args.Add("--no-confirm");
+        if (NoConfirmSettings.Resolve(NoConfirmSettings.AurInstall)) args.Add("--no-confirm");
 
         return await ExecuteJsonCommandAsync<PackageBuild>("AUR package builds",
             () => processExecutor.RunPrivilegedShellyCommandAsync("Get Package Builds", args.ToArray()));

--- a/Shelly.Gtk/UiFiles/SettingWindow.ui
+++ b/Shelly.Gtk/UiFiles/SettingWindow.ui
@@ -526,13 +526,234 @@
                                                                 <property name="orientation">horizontal</property>
                                                                 <child>
                                                                     <object class="GtkLabel">
-                                                                        <property name="label" translatable="yes">No Confirm</property>
+                                                                        <property name="label" translatable="yes">No Confirm - All Actions</property>
                                                                         <property name="halign">start</property>
                                                                         <property name="hexpand">true</property>
                                                                     </object>
                                                                 </child>
                                                                 <child>
-                                                                    <object class="GtkSwitch" id="no_confirm_switch">
+                                                                    <object class="GtkSwitch" id="no_confirm_all_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Upgrade</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_upgrade_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Install</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_install_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Remove</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_remove_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Downgrade</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_downgrade_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - AUR Install</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_aur_install_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - AUR Remove</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_aur_remove_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - AUR Upgrade</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_aur_upgrade_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Flatpak Install</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_flatpak_install_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Flatpak Remove</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_flatpak_remove_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - Flatpak Upgrade</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_flatpak_upgrade_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - AppImage Remove</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_appimage_remove_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">No Confirm - AppImage Upgrade</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="no_confirm_appimage_upgrade_switch">
+                                                                        <property name="halign">end</property>
+                                                                    </object>
+                                                                </child>
+                                                            </object>
+                                                        </child>
+                                                        <child>
+                                                            <object class="GtkBox">
+                                                                <property name="orientation">horizontal</property>
+                                                                <child>
+                                                                    <object class="GtkLabel">
+                                                                        <property name="label" translatable="yes">Default Yes Prompt (Y/n)</property>
+                                                                        <property name="halign">start</property>
+                                                                        <property name="hexpand">true</property>
+                                                                    </object>
+                                                                </child>
+                                                                <child>
+                                                                    <object class="GtkSwitch" id="default_yes_prompt_switch">
                                                                         <property name="halign">end</property>
                                                                     </object>
                                                                 </child>

--- a/Shelly.Gtk/Windows/AUR/AurInstall.cs
+++ b/Shelly.Gtk/Windows/AUR/AurInstall.cs
@@ -444,7 +444,7 @@ public class AurInstall(
 
             try
             {
-                if (!configService.LoadConfig().NoConfirm)
+                if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.AurInstall))
                 {
                     var args = new GenericQuestionEventArgs(
                         T("Install Packages?"), string.Join("\n", selectedPackages)

--- a/Shelly.Gtk/Windows/AUR/AurRemove.cs
+++ b/Shelly.Gtk/Windows/AUR/AurRemove.cs
@@ -362,7 +362,7 @@ public class AurRemove(
 
         if (selectedPackages.Count != 0)
         {
-            if (!configService.LoadConfig().NoConfirm)
+            if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.AurRemove))
             {
                 var args = new GenericQuestionEventArgs(
                     T("Remove Packages?"), string.Join("\n", selectedPackages)

--- a/Shelly.Gtk/Windows/AUR/AurUpdate.cs
+++ b/Shelly.Gtk/Windows/AUR/AurUpdate.cs
@@ -398,7 +398,7 @@ public class AurUpdate(
 
         if (selectedPackages.Count != 0)
         {
-            if (!configService.LoadConfig().NoConfirm)
+            if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.AurUpgrade))
             {
                 var args = new GenericQuestionEventArgs(
                     T("Update Packages?"), string.Join("\n", selectedPackages)

--- a/Shelly.Gtk/Windows/Flatpak/FlatpakInstall.cs
+++ b/Shelly.Gtk/Windows/Flatpak/FlatpakInstall.cs
@@ -1174,7 +1174,7 @@ public class FlatpakInstall(
 
     private async Task InstallSelectedAsync()
     {
-        if (!configService.LoadConfig().NoConfirm)
+        if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.FlatpakInstall))
         {
             var args = new GenericQuestionEventArgs(
                 Translations.T("Install Package?"), _selectedPackage.Id
@@ -1247,7 +1247,7 @@ public class FlatpakInstall(
         
         var selectedRemote = remote ?? _selectedRemote;
         
-        if (!configService.LoadConfig().NoConfirm)
+        if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.FlatpakInstall))
         {
             var args = new GenericQuestionEventArgs(
                 Translations.T("Install Package?"), id

--- a/Shelly.Gtk/Windows/Flatpak/FlatpakUpdate.cs
+++ b/Shelly.Gtk/Windows/Flatpak/FlatpakUpdate.cs
@@ -230,7 +230,7 @@ public class FlatpakUpdate(
 
     private async Task UpdateAllCommand()
     {
-        if (!configService.LoadConfig().NoConfirm)
+        if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.FlatpakUpgrade))
         {
             var args = new GenericQuestionEventArgs(
                 Translations.T("Update Packages?"), string.Join("\n", _allPackages.Select(x => x.Id))

--- a/Shelly.Gtk/Windows/Packages/PackageInstall.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageInstall.cs
@@ -1170,7 +1170,7 @@ public sealed class PackageInstall(
 
             try
             {
-                if (!configService.LoadConfig().NoConfirm)
+                if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.Install))
                 {
                     var message = string.Join("\n", selectedPackages);
                     var performUpgradeForDialog = _upgradeCheck.GetActive();

--- a/Shelly.Gtk/Windows/Packages/PackageManagement.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageManagement.cs
@@ -1128,7 +1128,7 @@ public sealed class PackageManagement(
 
         if (selectedPackages.Count != 0)
         {
-            if (!configService.LoadConfig().NoConfirm)
+            if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.Remove))
             {
                 var args = new GenericQuestionEventArgs(
                     T("Remove Packages?"), string.Join("\n", selectedPackages)

--- a/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
+++ b/Shelly.Gtk/Windows/Packages/PackageUpdate.cs
@@ -920,7 +920,7 @@ public class PackageUpdate(
 
         if (selectedPackages.Count != 0)
         {
-            if (!configService.LoadConfig().NoConfirm)
+            if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.Upgrade))
             {
                 var args = new GenericQuestionEventArgs(
                     T("Update Packages?"),

--- a/Shelly.Gtk/Windows/Packages/RemoveLocal.cs
+++ b/Shelly.Gtk/Windows/Packages/RemoveLocal.cs
@@ -224,7 +224,7 @@ public sealed class RemoveLocal(
 
         if (selectedPackages.Count != 0)
         {
-            if (!configService.LoadConfig().NoConfirm)
+            if (!configService.LoadConfig().NoConfirmSettings.Resolve(configService.LoadConfig().NoConfirmSettings.Remove))
             {
                 var args = new GenericQuestionEventArgs(
                     "Remove Packages?", string.Join("\n", selectedPackages)

--- a/Shelly.Gtk/Windows/Settings.cs
+++ b/Shelly.Gtk/Windows/Settings.cs
@@ -92,7 +92,20 @@ public sealed class Settings(
         SetupWeeklyScheduleSwitch("daily_schedule", _config.UseWeeklySchedule, (v) => _config.UseWeeklySchedule = v,
             builder);
         SetupStarfishSwitch("webview_switch", _config.StarFishEnabled, (v) => _config.StarFishEnabled = v, builder);
-        SetupSwitch("no_confirm_switch", _config.NoConfirm, (v) => _config.NoConfirm = v, builder);
+        SetupSwitch("no_confirm_all_switch", _config.NoConfirmSettings.All, (v) => { _config.NoConfirmSettings.All = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_upgrade_switch", _config.NoConfirmSettings.Upgrade, (v) => { _config.NoConfirmSettings.Upgrade = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_install_switch", _config.NoConfirmSettings.Install, (v) => { _config.NoConfirmSettings.Install = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_remove_switch", _config.NoConfirmSettings.Remove, (v) => { _config.NoConfirmSettings.Remove = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_downgrade_switch", _config.NoConfirmSettings.Downgrade, (v) => { _config.NoConfirmSettings.Downgrade = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_aur_install_switch", _config.NoConfirmSettings.AurInstall, (v) => { _config.NoConfirmSettings.AurInstall = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_aur_remove_switch", _config.NoConfirmSettings.AurRemove, (v) => { _config.NoConfirmSettings.AurRemove = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_aur_upgrade_switch", _config.NoConfirmSettings.AurUpgrade, (v) => { _config.NoConfirmSettings.AurUpgrade = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_flatpak_install_switch", _config.NoConfirmSettings.FlatpakInstall, (v) => { _config.NoConfirmSettings.FlatpakInstall = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_flatpak_remove_switch", _config.NoConfirmSettings.FlatpakRemove, (v) => { _config.NoConfirmSettings.FlatpakRemove = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_flatpak_upgrade_switch", _config.NoConfirmSettings.FlatpakUpgrade, (v) => { _config.NoConfirmSettings.FlatpakUpgrade = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_appimage_remove_switch", _config.NoConfirmSettings.AppImageRemove, (v) => { _config.NoConfirmSettings.AppImageRemove = v; SaveConfig(); }, builder);
+        SetupSwitch("no_confirm_appimage_upgrade_switch", _config.NoConfirmSettings.AppImageUpgrade, (v) => { _config.NoConfirmSettings.AppImageUpgrade = v; SaveConfig(); }, builder);
+        SetupSwitch("default_yes_prompt_switch", _config.NoConfirmSettings.DefaultYesPrompt, (v) => { _config.NoConfirmSettings.DefaultYesPrompt = v; SaveConfig(); }, builder);
         SetupSwitch("remove_cache_switch", _config.RemoveCache, (v) => _config.RemoveCache = v, builder);
         SetupSwitch("webview_switch", _config.StarFishEnabled, (v) => _config.StarFishEnabled = v, builder);
         SetupSwitch("recommended_switch", _config.RecommendedEnabled, (v) => _config.RecommendedEnabled = v, builder);

--- a/Shelly.Utilities/Models/NoConfirmSettings.cs
+++ b/Shelly.Utilities/Models/NoConfirmSettings.cs
@@ -1,0 +1,66 @@
+namespace Shelly.Utilities;
+
+/// <summary>
+/// Granular no-confirm settings per action type.
+/// Replaces the single global NoConfirm bool with per-action control.
+/// </summary>
+public class NoConfirmSettings
+{
+    // Backward compatibility: if old config has "NoConfirm": true, this maps to All = true
+    [System.Text.Json.Serialization.JsonPropertyName("All")]
+    public bool All { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("Upgrade")]
+    public bool Upgrade { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("Install")]
+    public bool Install { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("Remove")]
+    public bool Remove { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("Downgrade")]
+    public bool Downgrade { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("AurInstall")]
+    public bool AurInstall { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("AurRemove")]
+    public bool AurRemove { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("AurUpgrade")]
+    public bool AurUpgrade { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("FlatpakInstall")]
+    public bool FlatpakInstall { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("FlatpakRemove")]
+    public bool FlatpakRemove { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("FlatpakUpgrade")]
+    public bool FlatpakUpgrade { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("AppImageRemove")]
+    public bool AppImageRemove { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("AppImageUpgrade")]
+    public bool AppImageUpgrade { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("Purify")]
+    public bool Purify { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("Mark")]
+    public bool Mark { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("DefaultYesPrompt")]
+    public bool DefaultYesPrompt { get; set; }
+
+    /// <summary>
+    /// Resolves the effective value for a given action, checking the specific flag first,
+    /// then falling back to the global All setting.
+    /// </summary>
+    public bool Resolve(bool actionSpecific)
+    {
+        return All || actionSpecific;
+    }
+}

--- a/Shelly.Utilities/Models/ShellyConfig.cs
+++ b/Shelly.Utilities/Models/ShellyConfig.cs
@@ -22,7 +22,7 @@ public class ShellyConfig
     public bool UseOldMenu { get; set; }
     public bool TrayEnabled { get; set; } = true;
     public int TrayCheckIntervalHours { get; set; } = 72;
-    public bool NoConfirm { get; set; }
+    public NoConfirmSettings NoConfirmSettings { get; set; } = new();
     public bool NewInstall { get; set; } = true;
     public string CurrentVersion { get; set; } = "0.0.0.0";
     public bool UseWeeklySchedule { get; set; }


### PR DESCRIPTION
Replace the single global NoConfirm boolean with per-action confirmation control and a default-yes prompt option.

**What changed:**

1. **Per-action no-confirm** — 14 new toggles: Upgrade, Install, Remove, Downgrade, AurInstall, AurRemove, AurUpgrade, FlatpakInstall, FlatpakRemove, FlatpakUpgrade, AppImageRemove, AppImageUpgrade, Purify, Mark. Plus a global `All` flag.

2. **Default-yes prompt (Y/n)** — new `DefaultYesPrompt` config option. When enabled, all confirmation prompts show `Y/n` instead of `y/N`, so pressing Enter proceeds. Shows the prompt but defaults to yes.

3. **CLI flags** — 14 new `--no-confirm-<action>` flags. Global `-n` still works as override for all actions.

4. **GTK Settings UI** — per-action switches + DefaultYesPrompt toggle.

5. **Backward compatible** — old `NoConfirm: true/false` in config.json maps to `NoConfirmSettings.All`.

**Resolution priority:** per-action CLI flag > per-action config > global CLI flag (-n) > global config All

**Config example:**
```json
"NoConfirmSettings": {
  "All": false,
  "Upgrade": true,
  "Install": false,
  "Remove": false,
  "DefaultYesPrompt": true
}
```