### PR TITLE
fix(tray): context menu items render properly on DE's using libdbusmenu

### DIFF
--- a/Shelly.Notifications/src/dbus_menu.vala
+++ b/Shelly.Notifications/src/dbus_menu.vala
@@ -58,7 +58,7 @@ public class DBusMenuHandler : Object {
         switch (name) {
         case "type" :
             bool is_sep = (id == ID_SEP || id == ID_SEP2);
-            return new GLib.Variant.string (is_sep ? "separator" : "");
+            return new GLib.Variant.string (is_sep ? "separator" : "standard");
         case "label" :
             var dl = dynamic_label (id);
             return new GLib.Variant.string (dl ?? label_for (id));
@@ -170,7 +170,7 @@ public class DBusMenuHandler : Object {
         bool is_sub = (id == ID_SUB_STD || id == ID_SUB_AUR || id == ID_SUB_FLAT);
 
         if (want (all, wanted, "type"))
-            b.add ("{sv}", "type", new GLib.Variant.string (""));
+            b.add ("{sv}", "type", new GLib.Variant.string ("standard"));
 
         if (want (all, wanted, "label")) {
             var dl = dynamic_label (id);


### PR DESCRIPTION
Fixes #1304
XFCE and waybar uses libdbusmenu to build the context menu and unlike kde & gnomes more linient implementations, they don't fall through  to a standard item if they have an unknown type. they need a known type and "standard" is.

I've tested this on XFCE, Kde, XFCE and sway (waybar) after changes, all render fine and as expected.

<img width="278" height="223" alt="Screenshot_20260708_212619" src="https://github.com/user-attachments/assets/b36d7319-edc7-417a-bcaa-372a8d41d018" />

<img width="278" height="223" alt="Screenshot_20260708_212608" src="https://github.com/user-attachments/assets/598f9e05-6475-4960-9492-21d391c2b948" />
