### PR TITLE
fix: Shelly not removing optional deps when declared name is a provides

### DIFF
--- a/Shelly.PackageManager/src/alpm/manager.zig
+++ b/Shelly.PackageManager/src/alpm/manager.zig
@@ -792,8 +792,8 @@ pub const Manager = struct {
                 var optional_deps = package.optional_depends();
                 while (optional_deps.next()) |deps| {
                     const dep_name = deps.name() orelse continue;
-                    // looks for local package continues on if failes to find.
-                    const local_ptr = rawLibalpm.alpm_db_get_pkg(local_db, dep_name.ptr) orelse {
+                    // looks for local package, then the satisfier, continues on if failes to find.
+                    const local_ptr = rawLibalpm.alpm_db_get_pkg(local_db, dep_name.ptr) orelse rawLibalpm.alpm_find_satisfier(rawLibalpm.alpm_db_get_pkgcache(local_db), dep_name.ptr) orelse {
                         const message = try std.fmt.allocPrint(self.allocator, "Failed to find {s} in local database. Skipping...", .{dep_name});
                         defer self.allocator.free(message);
                         self.dispatcher.raiseInformational(.{


### PR DESCRIPTION
Hi,
This PR fixes a bug where `-Rso` fails to remove an optional dependency if the name declared in the installed package differs from the actual package name.
This happens when the declared name is a provides name that differs from the actual package name.

---

Example:

Before
```
[blue@arch Shelly.Cli.Zig]$ sudo ./zig-out/bin/shelly -Is firefox
:: Installing packages: firefox
Select an optional dependency for firefox
  1) hunspell-en_US
  2) libnotify
  3) networkmanager
  4) onnxruntime
  5) speech-dispatcher
  6) xdg-desktop-portal
Select numbers separated by commas (none): 1
(1/1) AddStart mailcap-2.1.54-2-any.pkg ---------------------------------- 100%
(1/1) AddStart hunspell-en_us-2026.02.2 ---------------------------------- 100%
(1/1) AddStart mailcap-2.1.54-2-any.pkg ---------------------------------- 100%
(1/1) AddStart hunspell-en_us-2026.02.2 ---------------------------------- 100%
(1/1) AddStart firefox-152.0.6-1-x86_64 ---------------------------------- 100%
(1/1) AddStart firefox-152.0.6-1-x86_64 ---------------------------------- 100%
(3/3) KeyringStart                      ---------------------------------- 100%
(3/3) IntegrityStart                    ---------------------------------- 100%
(3/3) LoadStart                         ---------------------------------- 100%
(3/3) ConflictsStart                    ---------------------------------- 100%
(3/3) DiskspaceStart                    ---------------------------------- 100%
(1/3) AddStart mailcap                  ---------------------------------- 100%
(2/3) AddStart firefox                  ---------------------------------- 100%
(3/3) AddStart hunspell-en_us           ---------------------------------- 100%
Hook: (1/3) Arming ConditionNeedsUpdate...
Hook: (2/3) Updating icon theme caches...
Hook: (3/3) Updating the desktop file MIME type cache...
:: Transaction complete.
[blue@arch Shelly.Cli.Zig]$ sudo ./zig-out/bin/shelly -Rso firefox
:: Removing packages: firefox
(1/2) RemoveStart firefox               ---------------------------------- 100%
(2/2) RemoveStart mailcap               ---------------------------------- 100%
Hook: (1/3) Arming ConditionNeedsUpdate...
Hook: (2/3) Updating icon theme caches...
Hook: (3/3) Updating the desktop file MIME type cache...
:: Transaction complete.
[blue@arch Shelly.Cli.Zig]$ pacman -Qi hunspell-en_US
Name            : hunspell-en_us <--- Actual name
Version         : 2026.02.25-1
Description     : US English hunspell dictionaries
Architecture    : any
URL             : http://wordlist.aspell.net/dicts/
Licenses        : LGPL-2.1-or-later  LGPL-2.1-only  BSD-3-Clause-Modification
Groups          : None
Provides        : hunspell-dictionary  hunspell-en_US <--- declared name (the one that Shelly searches)
Depends On      : None
Optional Deps   : hunspell: the spell checking libraries and apps [installed]
Required By     : None
Optional For    : None
Conflicts With  : hunspell-en_US
Replaces        : hunspell-en_US<=2020.12.07-1
Installed Size  : 2.13 MiB
Packager        : Andreas Radke <andyrtr@archlinux.org>
Build Date      : Thu 26 Feb 2026 05:18:02 PM CET
Install Date    : Mon 20 Jul 2026 10:54:27 PM CEST
Install Reason  : Installed as a dependency for another package
Install Script  : No
Validated By    : Signature
```

After:
```
[blue@arch Shelly.Cli.Zig]$ sudo ./zig-out/bin/shelly -Is firefox
:: Installing packages: firefox
Select an optional dependency for firefox
  1) hunspell-en_US
  2) libnotify
  3) networkmanager
  4) onnxruntime
  5) speech-dispatcher
  6) xdg-desktop-portal
Select numbers separated by commas (none): 1
(1/1) AddStart mailcap-2.1.54-2-any.pkg ---------------------------------- 100%
(1/1) AddStart hunspell-en_us-2026.02.2 ---------------------------------- 100%
(1/1) AddStart mailcap-2.1.54-2-any.pkg ---------------------------------- 100%
(1/1) AddStart hunspell-en_us-2026.02.2 ---------------------------------- 100%
(1/1) AddStart firefox-152.0.6-1-x86_64 ---------------------------------- 100%
(1/1) AddStart firefox-152.0.6-1-x86_64 ---------------------------------- 100%
(3/3) KeyringStart                      ---------------------------------- 100%
(3/3) IntegrityStart                    ---------------------------------- 100%
(3/3) LoadStart                         ---------------------------------- 100%
(3/3) ConflictsStart                    ---------------------------------- 100%
(3/3) DiskspaceStart                    ---------------------------------- 100%
(1/3) AddStart mailcap                  ---------------------------------- 100%
(2/3) AddStart firefox                  ---------------------------------- 100%
(3/3) AddStart hunspell-en_us           ---------------------------------- 100%
Hook: (1/3) Arming ConditionNeedsUpdate...
Hook: (2/3) Updating icon theme caches...
Hook: (3/3) Updating the desktop file MIME type cache...
:: Transaction complete.
[blue@arch Shelly.Cli.Zig]$ sudo ./zig-out/bin/shelly -Rso firefox
:: Removing packages: firefox
(1/3) RemoveStart hunspell-en_us        ---------------------------------- 100%
(2/3) RemoveStart firefox               ---------------------------------- 100%
(3/3) RemoveStart mailcap               ---------------------------------- 100%
Hook: (1/3) Arming ConditionNeedsUpdate...
Hook: (2/3) Updating icon theme caches...
Hook: (3/3) Updating the desktop file MIME type cache...
:: Transaction complete.
[blue@arch Shelly.Cli.Zig]$ pacman -Qi hunspell-en_US
error: package 'hunspell-en_US' was not found
```

---

The fix adds a fallback search using `alpm_find_satisfier`, which matches both package names and provides entries.
This is the same pattern used [here](https://github.com/SimoneFelici/Shelly-ALPM/blob/75e1ed823b0036a6acec560e91119668bbd30b5a/Shelly.PackageManager/src/alpm/manager.zig#L762).

---

Please let me know if you have any questions,
Thank you!