### PR TITLE
Check arch news when running shelly upgrade-all

### DIFF
--- a/Shelly.Cli/Commands/Standard/UpgradeAll.cs
+++ b/Shelly.Cli/Commands/Standard/UpgradeAll.cs
@@ -80,6 +80,8 @@ public class UpgradeAll : GlobalSettingsCommand
             return;
         }
 
+        var archNews = new ArchNews();
+        await archNews.ExecuteAsync(console);
 
         if (!UserIdentity.IsRoot())
         {


### PR DESCRIPTION
Currently, Arch news is displayed **after** you confirm the system upgrade when upgrading via `shelly` or `shelly upgrade-all` (unlike `shelly upgrade`).

This pull request adds the news check to `UpgradeAll.cs` before the confirmation prompt. 

Duplicate news output is prevented since the local cache is updated on the news check.

This is specifically a fix for the C# version, not sure if something needs to be done in the Zig rewrite as well.