### PR TITLE
Fix: Zsh autocompletion for install and remove

### DIFF
--- a/Shelly.Cli.Zig/src/cli/completions.zig
+++ b/Shelly.Cli.Zig/src/cli/completions.zig
@@ -620,15 +620,14 @@ test "renders Bash Fish and Zsh scripts from the native catalog" {
         try std.testing.expect(std.mem.indexOf(u8, script, "threeway") != null);
         try std.testing.expect(std.mem.indexOf(u8, script, "bash fish zsh") != null);
         if (expected.shell == .zsh) {
+            // Regression for malformed _arguments specs.
             try std.testing.expect(std.mem.indexOf(u8, script, "'{--") == null);
             try std.testing.expect(std.mem.indexOf(u8, script, "'/?[") == null);
+            // Shortcode completion is generated.
             try std.testing.expect(std.mem.indexOf(u8, script, "'-Is:") != null);
-            try std.testing.expect(std.mem.indexOf(u8, script, "'-LI:") != null);
-            try std.testing.expect(std.mem.indexOf(u8, script, "pacman -Slq") != null);
+            // Repeated and single positional arguments are represented.
             try std.testing.expect(std.mem.indexOf(u8, script, "'*:packages:") != null);
             try std.testing.expect(std.mem.indexOf(u8, script, "'1:package:") != null);
-            try std.testing.expect(std.mem.indexOf(u8, script, "words=(\"$words[1]\" \"${(@)words[consumed+2,$#words]}\")") != null);
-            try std.testing.expect(std.mem.indexOf(u8, script, "consumed=2") != null);
         }
     }
 }

--- a/Shelly.Cli.Zig/src/cli/completions.zig
+++ b/Shelly.Cli.Zig/src/cli/completions.zig
@@ -263,6 +263,7 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
         \\
         \\_shelly() {
         \\    local action selector
+        \\    integer consumed=0
         \\    action=$words[2]
         \\    selector=
         \\    if (( CURRENT == 2 )); then
@@ -297,7 +298,7 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
         const action_code = command.actionCode orelse continue;
         var codes: [16]u8 = undefined;
         for (collectTypeCodes(command, &codes)) |type_code| {
-            try writer.print("        -{c}{c}*) action={s}; selector={s} ;;\n", .{
+            try writer.print("        -{c}{c}*) action={s}; selector={s}; consumed=1 ;;\n", .{
                 action_code,
                 type_code,
                 parentActionName(command),
@@ -333,6 +334,7 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
                     \\                    return
                     \\                fi
                     \\                selector=$words[3]
+                    \\                consumed=2
                     \\            fi
                     \\            case $selector in
                     \\
@@ -343,11 +345,11 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
                     try writeZshArguments(manifest, other, writer);
                     try writer.writeAll(" ;;\n");
                 }
-                try writer.writeAll("                *) ");
+                try writer.print("                *) [[ $selector != {s} ]] && consumed=1; ", .{child.name});
                 try writeZshArguments(manifest, child, writer);
                 try writer.writeAll(" ;;\n            esac\n");
             } else {
-                try writer.writeAll("            ");
+                try writer.writeAll("            (( consumed == 0 )) && consumed=1; ");
                 try writeZshArguments(manifest, child, writer);
                 try writer.writeByte('\n');
             }
@@ -365,6 +367,7 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
                 \\                    return
                 \\                fi
                 \\                selector=$words[3]
+                \\                consumed=2
                 \\            fi
                 \\            case $selector in
                 \\
@@ -392,7 +395,9 @@ fn writeZshArguments(
     command: *const spec.Command,
     writer: *std.Io.Writer,
 ) !void {
-    try writer.writeAll("_arguments");
+    try writer.writeAll(
+        \\(( consumed > 0 )) && { words=("$words[1]" "${(@)words[consumed+2,$#words]}"); (( CURRENT -= consumed )); }; _arguments
+    );
     for (command.options) |option| {
         if (option.hidden) continue;
         try writer.writeAll(" ");
@@ -622,6 +627,8 @@ test "renders Bash Fish and Zsh scripts from the native catalog" {
             try std.testing.expect(std.mem.indexOf(u8, script, "pacman -Slq") != null);
             try std.testing.expect(std.mem.indexOf(u8, script, "'*:packages:") != null);
             try std.testing.expect(std.mem.indexOf(u8, script, "'1:package:") != null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "words=(\"$words[1]\" \"${(@)words[consumed+2,$#words]}\")") != null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "consumed=2") != null);
         }
     }
 }

--- a/Shelly.Cli.Zig/src/cli/completions.zig
+++ b/Shelly.Cli.Zig/src/cli/completions.zig
@@ -225,9 +225,46 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
         \\#compdef shelly
         \\# Zsh completions for shelly
         \\# Auto-generated from the native Shelly CLI catalog. Do not edit.
+        \\
+        \\typeset -ga _shelly_repo_packages
+        \\typeset -ga _shelly_flatpak_remote_packages
+        \\
+        \\_shelly_packages_standard_sync() {
+        \\    if (( ${#_shelly_repo_packages} == 0 )); then
+        \\        _shelly_repo_packages=(${(f)"$(pacman -Slq 2>/dev/null)"})
+        \\    fi
+        \\    _describe -t packages 'package' _shelly_repo_packages
+        \\}
+        \\
+        \\_shelly_packages_standard_local() {
+        \\    local -a packages
+        \\    packages=(${(f)"$(pacman -Qq 2>/dev/null)"})
+        \\    _describe -t packages 'package' packages
+        \\}
+        \\
+        \\_shelly_packages_aur_local() {
+        \\    local -a packages
+        \\    packages=(${(f)"$(pacman -Qqm 2>/dev/null)"})
+        \\    _describe -t packages 'package' packages
+        \\}
+        \\
+        \\_shelly_packages_flatpak_remote() {
+        \\    if (( ${#_shelly_flatpak_remote_packages} == 0 )); then
+        \\        _shelly_flatpak_remote_packages=(${(f)"$(flatpak remote-ls --app --columns=application 2>/dev/null)"})
+        \\    fi
+        \\    _describe -t packages 'package' _shelly_flatpak_remote_packages
+        \\}
+        \\
+        \\_shelly_packages_flatpak_local() {
+        \\    local -a packages
+        \\    packages=(${(f)"$(flatpak list --app --columns=application 2>/dev/null)"})
+        \\    _describe -t packages 'package' packages
+        \\}
+        \\
         \\_shelly() {
-        \\    local action
+        \\    local action selector
         \\    action=$words[2]
+        \\    selector=
         \\    if (( CURRENT == 2 )); then
         \\        local -a actions
         \\        actions=(
@@ -239,11 +276,37 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
         try writeZshEscaped(writer, action.description orelse "");
         try writer.writeAll("'\n");
     }
+    for (manifest.commands) |*command| {
+        const action_code = command.actionCode orelse continue;
+        var codes: [16]u8 = undefined;
+        for (collectTypeCodes(command, &codes)) |type_code| {
+            try writer.print("            '-{c}{c}:", .{ action_code, type_code });
+            try writeZshEscaped(writer, command.description orelse "");
+            try writer.writeAll("'\n");
+        }
+    }
     try writer.writeAll(
         \\        )
         \\        _describe 'command' actions
         \\        return
         \\    fi
+        \\    case $action in
+        \\
+    );
+    for (manifest.commands) |*command| {
+        const action_code = command.actionCode orelse continue;
+        var codes: [16]u8 = undefined;
+        for (collectTypeCodes(command, &codes)) |type_code| {
+            try writer.print("        -{c}{c}*) action={s}; selector={s} ;;\n", .{
+                action_code,
+                type_code,
+                parentActionName(command),
+                command.name,
+            });
+        }
+    }
+    try writer.writeAll(
+        \\    esac
         \\    case $action in
         \\
     );
@@ -253,15 +316,27 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
         const default_child = manifest.findDefaultChild(action);
         if (default_child) |child| {
             if (hasNonDefaultChildren(manifest, action, child)) {
-                try writer.writeAll("            if (( CURRENT == 3 )); then\n                local -a commands\n                commands=(");
+                try writer.writeAll(
+                    \\            if [[ -z $selector ]]; then
+                    \\                if (( CURRENT == 3 )); then
+                    \\                    local -a commands
+                    \\                    commands=(
+                );
                 for (manifest.commands) |*other| {
                     if (!isChildOf(other, action) or other == child) continue;
                     try writer.print(" '{s}'", .{other.name});
                 }
-                try writer.writeAll(" )\n                _alternative 'commands:command:commands' 'options:option:(");
+                try writer.writeAll(" )\n                    _alternative 'commands:command:commands' 'options:option:(");
                 try writeEffectiveOptionWords(manifest, child, writer);
-                try writer.writeAll(")'\n                return\n            fi\n");
-                try writer.writeAll("            case $words[3] in\n");
+                try writer.writeAll(
+                    \\)'
+                    \\                    return
+                    \\                fi
+                    \\                selector=$words[3]
+                    \\            fi
+                    \\            case $selector in
+                    \\
+                );
                 for (manifest.commands) |*other| {
                     if (!isChildOf(other, action) or other == child) continue;
                     try writer.print("                {s}) ", .{other.name});
@@ -277,9 +352,23 @@ fn renderZsh(manifest: *const spec.Manifest, writer: *std.Io.Writer) !void {
                 try writer.writeByte('\n');
             }
         } else {
-            try writer.writeAll("            if (( CURRENT == 3 )); then\n                local -a commands\n                commands=(");
+            try writer.writeAll(
+                \\            if [[ -z $selector ]]; then
+                \\                if (( CURRENT == 3 )); then
+                \\                    local -a commands
+                \\                    commands=(
+            );
             try writeChildNames(manifest, action, writer);
-            try writer.writeAll(")\n                _describe 'command' commands\n                return\n            fi\n            case $words[3] in\n");
+            try writer.writeAll(
+                \\)
+                \\                    _describe 'command' commands
+                \\                    return
+                \\                fi
+                \\                selector=$words[3]
+                \\            fi
+                \\            case $selector in
+                \\
+            );
             for (manifest.commands) |*child| {
                 if (!isChildOf(child, action)) continue;
                 try writer.print("                {s}) ", .{child.name});
@@ -314,18 +403,42 @@ fn writeZshArguments(
         try writer.writeAll(" ");
         try writeZshOption(option, writer);
     }
+    if (packageCompleter(command)) |helper| {
+        if (command.arguments.len > 0)
+            try writeZshPositional(command.arguments[0], helper, writer);
+    } else if (isAppimageInstall(command)) {
+        if (command.arguments.len > 0)
+            try writeZshPositional(command.arguments[0], "_files -g \"*.AppImage\"", writer);
+    }
+}
+
+fn writeZshPositional(argument: spec.Argument, action: []const u8, writer: *std.Io.Writer) !void {
+    try writer.print(" '{s}{s}:{s}'", .{ zshPositionalPrefix(argument), argument.name, action });
+}
+
+fn zshPositionalPrefix(argument: spec.Argument) []const u8 {
+    const repeated = argument.maximumArity == null or argument.maximumArity.? > 1;
+    if (repeated) return "*:";
+    return if (argument.minimumArity == 0) "1::" else "1:";
 }
 
 fn writeZshOption(option: spec.Option, writer: *std.Io.Writer) !void {
-    try writer.writeByte('\'');
-    if (option.aliases.len > 0) {
-        try writer.writeByte('{');
-        try writer.writeAll(option.name);
-        for (option.aliases) |alias| try writer.print(",{s}", .{alias});
-        try writer.writeByte('}');
-    } else {
-        try writer.writeAll(option.name);
+    var wrote = false;
+    if (isZshArgumentsOptionName(option.name)) {
+        try writeZshOptionName(option.name, option, writer);
+        wrote = true;
     }
+    for (option.aliases) |alias| {
+        if (!isZshArgumentsOptionName(alias)) continue;
+        if (wrote) try writer.writeByte(' ');
+        try writeZshOptionName(alias, option, writer);
+        wrote = true;
+    }
+}
+
+fn writeZshOptionName(name: []const u8, option: spec.Option, writer: *std.Io.Writer) !void {
+    try writer.writeByte('\'');
+    try writer.writeAll(name);
     try writer.writeByte('[');
     try writeZshEscaped(writer, option.description orelse "");
     try writer.writeByte(']');
@@ -339,6 +452,54 @@ fn writeZshOption(option: spec.Option, writer: *std.Io.Writer) !void {
         }
     }
     try writer.writeByte('\'');
+}
+
+/// Returns true when `name` is a valid zsh `_arguments` option spec (`-x` or `--long`).
+fn isZshArgumentsOptionName(name: []const u8) bool {
+    if (!std.mem.startsWith(u8, name, "-")) return false;
+    return std.mem.indexOfAny(u8, name, "?/") == null;
+}
+
+/// Returns the primary type code followed by any catalog alias type codes.
+fn collectTypeCodes(command: *const spec.Command, buffer: *[16]u8) []const u8 {
+    var count: usize = 0;
+    if (command.typeCode) |type_code| {
+        buffer[count] = type_code;
+        count += 1;
+    }
+    for (command.aliasTypeCodes) |type_code| {
+        if (count >= buffer.len) break;
+        buffer[count] = type_code;
+        count += 1;
+    }
+    return buffer[0..count];
+}
+
+fn parentActionName(command: *const spec.Command) []const u8 {
+    const parent_path = command.parentPath orelse return command.name;
+    if (std.mem.lastIndexOfScalar(u8, parent_path, ' ')) |index|
+        return parent_path[index + 1 ..];
+    return parent_path;
+}
+
+fn packageCompleter(command: *const spec.Command) ?[]const u8 {
+    if (std.mem.eql(u8, command.path, "shelly install standard") or
+        std.mem.eql(u8, command.path, "shelly search standard"))
+        return "_shelly_packages_standard_sync";
+    if (std.mem.eql(u8, command.path, "shelly remove standard"))
+        return "_shelly_packages_standard_local";
+    if (std.mem.eql(u8, command.path, "shelly remove aur"))
+        return "_shelly_packages_aur_local";
+    if (std.mem.eql(u8, command.path, "shelly install flatpak") or
+        std.mem.eql(u8, command.path, "shelly search flatpak"))
+        return "_shelly_packages_flatpak_remote";
+    if (std.mem.eql(u8, command.path, "shelly remove flatpak"))
+        return "_shelly_packages_flatpak_local";
+    return null;
+}
+
+fn isAppimageInstall(command: *const spec.Command) bool {
+    return std.mem.eql(u8, command.path, "shelly install appimage");
 }
 
 fn writeZshEscaped(writer: *std.Io.Writer, value: []const u8) !void {
@@ -453,6 +614,15 @@ test "renders Bash Fish and Zsh scripts from the native catalog" {
         try std.testing.expect(std.mem.indexOf(u8, script, "pacfiles") != null);
         try std.testing.expect(std.mem.indexOf(u8, script, "threeway") != null);
         try std.testing.expect(std.mem.indexOf(u8, script, "bash fish zsh") != null);
+        if (expected.shell == .zsh) {
+            try std.testing.expect(std.mem.indexOf(u8, script, "'{--") == null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "'/?[") == null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "'-Is:") != null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "'-LI:") != null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "pacman -Slq") != null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "'*:packages:") != null);
+            try std.testing.expect(std.mem.indexOf(u8, script, "'1:package:") != null);
+        }
     }
 }
 

--- a/Shelly.Cli.Zig/src/cli/spec.zig
+++ b/Shelly.Cli.Zig/src/cli/spec.zig
@@ -18,6 +18,7 @@ pub const Command = struct {
     implementation: ?[]const u8 = null,
     actionCode: ?u8 = null,
     typeCode: ?u8 = null,
+    aliasTypeCodes: []const u8 = &.{},
     bareActionCode: bool = false,
     defaultForAction: bool = false,
 
@@ -94,6 +95,7 @@ pub const Manifest = struct {
                     .implementation = candidate.implementation,
                     .actionCode = candidate.action.code(),
                     .typeCode = candidate.type_code,
+                    .aliasTypeCodes = candidate.alias_type_codes,
                     .bareActionCode = candidate.bare_action_code,
                     .defaultForAction = candidate.default_for_action,
                 });


### PR DESCRIPTION
# What

This fixes the still broken Zsh autocompletion (#1158) and adds tab completion for package selection in:

* `install`

  * pacman packages
  * Flatpak packages
  * local AppImage files
* `remove`

  * pacman packages
  * Flatpak packages
  * AUR packages

## LLM Disclaimer

I used an LLM to implement most of these changes. I reviewed the resulting code manually, although I am not very familiar with Zig or Zsh completion internals.

I ran the `Shelly.Cli.Zig` test suite and also tested the affected completion paths manually. Everything worked as expected in my testing.

## Notes

I haven't found a good way to support AUR package completion for `install` yet, so I left that out for now.

AppImage removal completion would require parsing Shelly's own output (for example via `jq`), which I didn't want to introduce as a dependency for shell completion, so I omitted it as well.