### PR TITLE
Preserve sidebar search across categories

### DIFF
--- a/Shelly.Ui.Gtk/src/helpers/c_string.zig
+++ b/Shelly.Ui.Gtk/src/helpers/c_string.zig
@@ -1,6 +1,13 @@
+const gtk = @import("Shelly_Ui_Gtk").gtk;
+
 pub fn cstr(buf: []u8, s: []const u8) [:0]const u8 {
     const len = @min(s.len, buf.len - 1);
     @memcpy(buf[0..len], s[0..len]);
     buf[len] = 0;
     return buf[0..len :0];
+}
+
+pub fn setEditableText(editable: *gtk.Editable, text: []const u8) void {
+    var buf: [257]u8 = undefined;
+    gtk.Editable.setText(editable, cstr(&buf, text));
 }

--- a/Shelly.Ui.Gtk/src/pages/appimage_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/appimage_page.zig
@@ -193,22 +193,7 @@ pub const AppImagePage = extern struct {
         thread.detach();
     }
 
-    pub fn onUnmap(self: *Self) void {
-        const p = self.priv();
-        if (!p.loaded) return;
-        p.loaded = false;
-
-        gtk.ListBox.removeAll(p.app_list);
-
-        if (p.arena) |a| {
-            a.deinit();
-            std.heap.c_allocator.destroy(a);
-            p.arena = null;
-        }
-        p.apps = &.{};
-        p.updates = &.{};
-        p.selected_index = null;
-    }
+    pub fn onUnmap(_: *Self) void {}
 
     fn reload(self: *Self) void {
         const p = self.priv();

--- a/Shelly.Ui.Gtk/src/pages/appimage_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/appimage_page.zig
@@ -195,6 +195,17 @@ pub const AppImagePage = extern struct {
 
     pub fn onUnmap(_: *Self) void {}
 
+    pub fn search_text(self: *Self) []const u8 {
+        const p = self.priv();
+        return std.mem.span(gtk.Editable.getText(p.search_entry.as(gtk.Editable)));
+    }
+
+    pub fn apply_search(self: *Self, query: []const u8) void {
+        const p = self.priv();
+        c_string.setEditableText(p.search_entry.as(gtk.Editable), query);
+        apply_search_filter(self);
+    }
+
     fn reload(self: *Self) void {
         const p = self.priv();
         p.generation += 1;

--- a/Shelly.Ui.Gtk/src/pages/aur_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/aur_page.zig
@@ -15,6 +15,7 @@ const ShellyConfig = @import("../models/shelly_config.zig").ShellyConfig;
 const AurPackageDetail = @import("aur_package_detail.zig").PackageDetail;
 const translations = @import("../helpers/translations.zig");
 const sorters = @import("../helpers/sorters.zig");
+const c_string = @import("../helpers/c_string.zig");
 
 pub const AurPage = extern struct {
     parent_instance: Parent,
@@ -545,6 +546,15 @@ pub const AurPage = extern struct {
 
     pub fn onUnmap(_: *Self) void {}
 
+    pub fn search_text(self: *Self) []const u8 {
+        return std.mem.span(gtk.Editable.getText(self.priv().search_entry.as(gtk.Editable)));
+    }
+
+    pub fn apply_search(self: *Self, query: []const u8) void {
+        c_string.setEditableText(self.priv().search_entry.as(gtk.Editable), query);
+        self.run_search_from_entry();
+    }
+
     fn start_load(self: *Self, mode: Mode) void {
         const p = self.priv();
         p.generation += 1;
@@ -682,16 +692,18 @@ pub const AurPage = extern struct {
         return 0;
     }
 
-    fn search_text(self: *Self) [:0]const u8 {
-        const p = self.priv();
-        return std.mem.span(gtk.Editable.getText(p.search_entry.as(gtk.Editable)));
+    fn on_search_activate(self: *Self) callconv(.c) void {
+        self.run_search_from_entry();
     }
 
-    fn on_search_activate(self: *Self) callconv(.c) void {
+    fn run_search_from_entry(self: *Self) void {
         const p = self.priv();
 
         if (p.installed_mode) {
+            p.applying_config = true;
             gtk.CheckButton.setActive(p.installed_toggle, 0);
+            p.applying_config = false;
+            p.installed_mode = false;
         }
 
         const text = self.search_text();
@@ -700,6 +712,11 @@ pub const AurPage = extern struct {
             gio.ListStore.removeAll(p.list_store);
             self.update_selection_ui();
             self.set_state(.prompt);
+            return;
+        }
+
+        const n_items = gio.ListModel.getNItems(p.list_store.as(gio.ListModel));
+        if (n_items > 0 and std.mem.eql(u8, text, p.last_query[0..p.last_query_len])) {
             return;
         }
 
@@ -712,6 +729,7 @@ pub const AurPage = extern struct {
 
     fn on_installed_toggled(self: *Self) callconv(.c) void {
         const p = self.priv();
+        if (p.applying_config) return;
         p.installed_mode = gtk.CheckButton.getActive(p.installed_toggle) != 0;
 
         if (p.installed_mode) {

--- a/Shelly.Ui.Gtk/src/pages/aur_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/aur_page.zig
@@ -543,24 +543,7 @@ pub const AurPage = extern struct {
         };
     }
 
-    extern fn malloc_trim(pad: usize) c_int;
-
-    pub fn onUnmap(self: *Self) void {
-        const p = self.priv();
-        if (!p.loaded) return;
-        p.loaded = false;
-
-        p.generation += 1;
-        gio.ListStore.removeAll(p.list_store);
-
-        if (p.arena) |a| {
-            a.deinit();
-            std.heap.c_allocator.destroy(a);
-            p.arena = null;
-        }
-
-        _ = malloc_trim(0);
-    }
+    pub fn onUnmap(_: *Self) void {}
 
     fn start_load(self: *Self, mode: Mode) void {
         const p = self.priv();

--- a/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_install_view.zig
+++ b/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_install_view.zig
@@ -29,7 +29,6 @@ const translations = @import("../../helpers/translations.zig");
 extern fn g_get_user_data_dir() [*:0]const u8;
 extern fn g_file_test(filename: [*:0]const u8, flags: c_uint) c_int;
 extern fn g_strndup(str: [*]const u8, len: usize) [*:0]u8;
-extern fn malloc_trim(pad: usize) c_int;
 
 pub const FlatpakInstallView = extern struct {
     parent_instance: Parent,
@@ -182,16 +181,7 @@ pub const FlatpakInstallView = extern struct {
         self.load_apps(p.load_generation);
     }
 
-    pub fn onUnmap(self: *Self) void {
-        const p = self.priv();
-        if (!p.loaded) return;
-        p.loaded = false;
-        p.load_generation +%= 1;
-        gtk.Widget.setVisible(p.loading_overlay.as(gtk.Widget), 0);
-        self.show_list();
-        if (p.model) |model| gio.ListStore.removeAll(model);
-        _ = malloc_trim(0);
-    }
+    pub fn onUnmap(_: *Self) void {}
 
     fn setup_grid(self: *Self) void {
         const p = self.priv();

--- a/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_page.zig
@@ -257,11 +257,7 @@ pub const FlatpakPage = extern struct {
         };
     }
 
-    pub fn onUnmap(self: *Self) void {
-        const p = self.priv();
-        if (!p.loaded) return;
-        p.loaded = false;
-    }
+    pub fn onUnmap(_: *Self) void {}
 
     const template_children = .{
         .{ "main_content_stack", @offsetOf(Private, "main_content_stack") },

--- a/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_page.zig
@@ -12,6 +12,7 @@ const FlatpakRemotesView = @import("flatpak_remotes_view.zig").FlatpakRemotesVie
 const FlatpakInstallLocalView = @import("flatpak_install_local_view.zig").FlatpakInstallLocalView;
 const Category = @import("../../models/flatpak.zig").Category;
 const translations = @import("../../helpers/translations.zig");
+const c_string = @import("../../helpers/c_string.zig");
 
 pub const FlatpakPage = extern struct {
     parent_instance: Parent,
@@ -258,6 +259,18 @@ pub const FlatpakPage = extern struct {
     }
 
     pub fn onUnmap(_: *Self) void {}
+
+    pub fn search_text(self: *Self) []const u8 {
+        const p = self.priv();
+        return std.mem.span(gtk.Editable.getText(p.search_entry.as(gtk.Editable)));
+    }
+
+    pub fn apply_search(self: *Self, query: []const u8) void {
+        const p = self.priv();
+        c_string.setEditableText(p.search_entry.as(gtk.Editable), query);
+        p.install_view.apply_search(query);
+        p.remove_view.applySearch(query);
+    }
 
     const template_children = .{
         .{ "main_content_stack", @offsetOf(Private, "main_content_stack") },

--- a/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_remove_view.zig
+++ b/Shelly.Ui.Gtk/src/pages/flatpak/flatpak_remove_view.zig
@@ -261,20 +261,7 @@ pub const FlatpakRemoveView = extern struct {
         thread.detach();
     }
 
-    pub fn onUnmap(self: *Self) void {
-        const p = self.priv();
-        if (!p.loaded) return;
-        p.loaded = false;
-
-        gio.ListStore.removeAll(p.list_store);
-        p.generation += 1;
-
-        if (p.arena) |a| {
-            a.deinit();
-            std.heap.c_allocator.destroy(a);
-            p.arena = null;
-        }
-    }
+    pub fn onUnmap(_: *Self) void {}
 
     fn load_worker(page: *Self, generation: u64) void {
         const arena_ptr = std.heap.c_allocator.create(std.heap.ArenaAllocator) catch return;

--- a/Shelly.Ui.Gtk/src/pages/package_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/package_page.zig
@@ -704,27 +704,7 @@ pub const PackagePage = extern struct {
         };
     }
 
-    extern fn malloc_trim(pad: usize) c_int;
-
-    //Unmap stuff we owned
-    pub fn onUnmap(self: *Self) void {
-        const p = self.priv();
-        if (!p.loaded) return;
-        p.loaded = false;
-
-        gio.ListStore.removeAll(p.list_store);
-
-        if (p.arena) |a| {
-            a.deinit();
-            std.heap.c_allocator.destroy(a);
-            p.arena = null;
-        }
-
-        p.resolver.deinit();
-        p.resolver = IconResolver.init(std.heap.c_allocator);
-
-        _ = malloc_trim(0);
-    }
+    pub fn onUnmap(_: *Self) void {}
 
     fn load_worker(page: *Self, generation: u64, show_hidden: bool) void {
         const arena_ptr = std.heap.c_allocator.create(std.heap.ArenaAllocator) catch return;

--- a/Shelly.Ui.Gtk/src/pages/package_page.zig
+++ b/Shelly.Ui.Gtk/src/pages/package_page.zig
@@ -706,6 +706,20 @@ pub const PackagePage = extern struct {
 
     pub fn onUnmap(_: *Self) void {}
 
+    pub fn search_text(self: *Self) []const u8 {
+        const p = self.priv();
+        return std.mem.span(gtk.Editable.getText(p.search_entry.as(gtk.Editable)));
+    }
+
+    pub fn apply_search(self: *Self, query: []const u8) void {
+        const p = self.priv();
+        c_string.setEditableText(p.search_entry.as(gtk.Editable), query);
+        const len = @min(query.len, p.search_text.len);
+        @memcpy(p.search_text[0..len], query[0..len]);
+        p.search_len = len;
+        gtk.Filter.changed(p.filter.as(gtk.Filter), .different);
+    }
+
     fn load_worker(page: *Self, generation: u64, show_hidden: bool) void {
         const arena_ptr = std.heap.c_allocator.create(std.heap.ArenaAllocator) catch return;
         arena_ptr.* = std.heap.ArenaAllocator.init(std.heap.c_allocator);

--- a/Shelly.Ui.Gtk/src/shelly_window.zig
+++ b/Shelly.Ui.Gtk/src/shelly_window.zig
@@ -402,9 +402,69 @@ pub const ShellyWindow = extern struct {
         gtk.Box.append(parent_box, btn.as(gtk.Widget));
     }
 
+    fn is_searchable_name(name: []const u8) bool {
+        return std.mem.eql(u8, name, "package") or
+            std.mem.eql(u8, name, "aur") or
+            std.mem.eql(u8, name, "flatpak") or
+            std.mem.eql(u8, name, "appimage");
+    }
+
+    const SearchablePage = union(enum) {
+        package: *PackagePage,
+        aur: *AurPage,
+        flatpak: *FlatpakPage,
+        appimage: *AppImagePage,
+    };
+
+    fn searchable_page(stack: *gtk.Stack, name: [:0]const u8) ?SearchablePage {
+        const child = gtk.Stack.getChildByName(stack, name) orelse return null;
+        if (std.mem.eql(u8, name, "package")) {
+            return .{ .package = gobject.ext.cast(PackagePage, child) orelse return null };
+        }
+        if (std.mem.eql(u8, name, "aur")) {
+            return .{ .aur = gobject.ext.cast(AurPage, child) orelse return null };
+        }
+        if (std.mem.eql(u8, name, "flatpak")) {
+            return .{ .flatpak = gobject.ext.cast(FlatpakPage, child) orelse return null };
+        }
+        if (std.mem.eql(u8, name, "appimage")) {
+            return .{ .appimage = gobject.ext.cast(AppImagePage, child) orelse return null };
+        }
+        return null;
+    }
+
     fn on_nav_click(_: *gtk.Button, nb: *NavButton) callconv(.c) void {
-        gtk.Stack.setVisibleChildName(nb.stack, nb.name);
+        const stack = nb.stack;
+        const dest_name = nb.name;
+        const current_z = gtk.Stack.getVisibleChildName(stack);
+        const current_name: [:0]const u8 = if (current_z) |cn| std.mem.span(cn) else "";
+
+        if (std.mem.eql(u8, current_name, dest_name)) return;
+
+        var query_buf: [256]u8 = undefined;
+        var query_len: usize = 0;
+        if (is_searchable_name(current_name) and is_searchable_name(dest_name)) {
+            if (searchable_page(stack, current_name)) |page| {
+                const q = switch (page) {
+                    inline else => |p| p.search_text(),
+                };
+                if (q.len > 0) {
+                    query_len = @min(q.len, query_buf.len);
+                    @memcpy(query_buf[0..query_len], q[0..query_len]);
+                }
+            }
+        }
+
+        gtk.Stack.setVisibleChildName(stack, dest_name);
         set_active_nav(nb.window, nb);
+
+        if (query_len > 0) {
+            if (searchable_page(stack, dest_name)) |page| {
+                switch (page) {
+                    inline else => |p| p.apply_search(query_buf[0..query_len]),
+                }
+            }
+        }
     }
 
     fn set_active_nav(self: *ShellyWindow, active: *NavButton) void {

--- a/Shelly.Ui.Gtk/src/shelly_window.zig
+++ b/Shelly.Ui.Gtk/src/shelly_window.zig
@@ -53,6 +53,10 @@ pub const ShellyWindow = extern struct {
         collapsed: bool,
         nav_mode: NavMode,
         pending_nav: NavMode,
+        /// Last query seen on a searchable sidebar page. Survives hops through
+        /// Update/Recommend/settings so Package → Updates → AUR still carries it.
+        last_search_query: [256]u8,
+        last_search_len: usize,
         var offset: c_int = 0;
     };
 
@@ -86,6 +90,7 @@ pub const ShellyWindow = extern struct {
         p.collapsed = true;
         p.nav_mode = .sidebar;
         p.pending_nav = .sidebar;
+        p.last_search_len = 0;
         build_shell(self);
         populate_stack(self);
         applyConfig(self);
@@ -433,38 +438,46 @@ pub const ShellyWindow = extern struct {
         return null;
     }
 
+    fn remember_search_from_current(self: *ShellyWindow) void {
+        const p = self.private();
+        const current_z = gtk.Stack.getVisibleChildName(p.content_stack) orelse return;
+        const current_name: [:0]const u8 = std.mem.span(current_z);
+        if (!is_searchable_name(current_name)) return;
+
+        const page = searchable_page(p.content_stack, current_name) orelse return;
+        const q = switch (page) {
+            inline else => |pg| pg.search_text(),
+        };
+        const len = @min(q.len, p.last_search_query.len);
+        @memcpy(p.last_search_query[0..len], q[0..len]);
+        p.last_search_len = len;
+    }
+
+    fn apply_remembered_search(self: *ShellyWindow, dest_name: [:0]const u8) void {
+        const p = self.private();
+        if (p.last_search_len == 0) return;
+        if (!is_searchable_name(dest_name)) return;
+
+        const page = searchable_page(p.content_stack, dest_name) orelse return;
+        switch (page) {
+            inline else => |pg| pg.apply_search(p.last_search_query[0..p.last_search_len]),
+        }
+    }
+
     fn on_nav_click(_: *gtk.Button, nb: *NavButton) callconv(.c) void {
-        const stack = nb.stack;
+        const self = nb.window;
         const dest_name = nb.name;
-        const current_z = gtk.Stack.getVisibleChildName(stack);
+        const current_z = gtk.Stack.getVisibleChildName(nb.stack);
         const current_name: [:0]const u8 = if (current_z) |cn| std.mem.span(cn) else "";
 
         if (std.mem.eql(u8, current_name, dest_name)) return;
 
-        var query_buf: [256]u8 = undefined;
-        var query_len: usize = 0;
-        if (is_searchable_name(current_name) and is_searchable_name(dest_name)) {
-            if (searchable_page(stack, current_name)) |page| {
-                const q = switch (page) {
-                    inline else => |p| p.search_text(),
-                };
-                if (q.len > 0) {
-                    query_len = @min(q.len, query_buf.len);
-                    @memcpy(query_buf[0..query_len], q[0..query_len]);
-                }
-            }
-        }
+        remember_search_from_current(self);
 
-        gtk.Stack.setVisibleChildName(stack, dest_name);
-        set_active_nav(nb.window, nb);
+        gtk.Stack.setVisibleChildName(nb.stack, dest_name);
+        set_active_nav(self, nb);
 
-        if (query_len > 0) {
-            if (searchable_page(stack, dest_name)) |page| {
-                switch (page) {
-                    inline else => |p| p.apply_search(query_buf[0..query_len]),
-                }
-            }
-        }
+        apply_remembered_search(self, dest_name);
     }
 
     fn set_active_nav(self: *ShellyWindow, active: *NavButton) void {
@@ -531,6 +544,7 @@ pub const ShellyWindow = extern struct {
 
     fn on_settings(btn: *gtk.Button, self: *ShellyWindow) callconv(.c) void {
         const p = self.private();
+        remember_search_from_current(self);
         gtk.Stack.setVisibleChildName(p.content_stack, "settings");
         if (gtk.Widget.getAncestor(btn.as(gtk.Widget), gtk.Popover.getGObjectType())) |pop| {
             gtk.Popover.popdown(@ptrCast(@alignCast(pop)));
@@ -539,6 +553,7 @@ pub const ShellyWindow = extern struct {
 
     fn on_utilities(btn: *gtk.Button, self: *ShellyWindow) callconv(.c) void {
         const p = self.private();
+        remember_search_from_current(self);
         gtk.Stack.setVisibleChildName(p.content_stack, "utilities");
         if (gtk.Widget.getAncestor(btn.as(gtk.Widget), gtk.Popover.getGObjectType())) |pop| {
             gtk.Popover.popdown(@ptrCast(@alignCast(pop)));


### PR DESCRIPTION
I found it annoying that when searching for a program and switching to another tab (e.g. package -> aur), the search did not carry over. 

I think it would be nice to keep results in memory and that way also decreasing the number of fetches.

the base idea is simply _sidebar click -> copy query (if both are searchable pages like e.g aur and packages) -> switch page while keeping old pages results -> put search on new page_

**package, flatpak, appimage** uses filters while for aur we seem to need to do a network request. 