### PR TITLE
help: fix backup import example to -Bi instead of -Bei (#1734)

### DIFF
--- a/Shelly.Cli.Zig/src/cli/help.zig
+++ b/Shelly.Cli.Zig/src/cli/help.zig
@@ -459,7 +459,8 @@ fn shortcodeUsage(
     try usage.appendSlice(allocator, try shortcodePrefix(allocator, command, option == null) orelse return null);
     if (option) |selected_option| {
         if (std.mem.eql(u8, command.path, "shelly backup utility") and
-            !std.mem.eql(u8, selected_option.name, "--export"))
+            !std.mem.eql(u8, selected_option.name, "--export") and
+            !std.mem.eql(u8, selected_option.name, "--import"))
             try usage.append(allocator, 'e');
         const alias = shortOptionAlias(selected_option) orelse return null;
         if (modifierMustBeSeparate(command, alias[1])) {
@@ -923,4 +924,30 @@ test "leaf examples keep ambiguous and bare-alias modifiers executable" {
     try std.testing.expect(std.mem.indexOf(u8, upgrade_all.writer.buffered(), "-U                  Shortcode") != null);
     try std.testing.expect(std.mem.indexOf(u8, upgrade_all.writer.buffered(), "-Uxh") != null);
     try std.testing.expect(std.mem.indexOf(u8, upgrade_all.writer.buffered(), "-Uh") == null);
+}
+
+test "backup import example uses -Bi, not the contradictory -Bei" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const manifest = try spec.Manifest.load(arena.allocator());
+    var output = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer output.deinit();
+
+    try render(
+        arena.allocator(),
+        &manifest,
+        manifest.findByPath("shelly backup utility").?,
+        &output.writer,
+    );
+    const rendered = output.writer.buffered();
+
+    // Import selects its own mode: the example must be -Bi. -Bei would combine
+    // export and import at once, which the parser rejects.
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "-Bi ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "-Bei") == null);
+
+    // Export mode and its export-scoped modifiers are unchanged.
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "-Be ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "-Bea <name>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "-Bed <directory>") != null);
 }


### PR DESCRIPTION
## Summary

`shelly backup --help` printed the import example as `-Bei`, but that shortcode expands to `backup -e -i` (export **and** import at once) and is rejected, so the printed example does not work. The correct import shortcode is `-Bi` → `backup -i`.

Fixes #1734.

## Root cause

In `Shelly.Cli.Zig/src/cli/help.zig`, `shortcodeUsage()` has a special case for the `shelly backup utility` command that prepends the export flag char `'e'` to every option's shortcode *except* `--export`. That is correct for the export-scoped modifiers (`--name` → `-Bea <name>`, `--directory` → `-Bed <directory>`), but it also caught `--import`, turning its example into `-Bei`.

## Fix

Exclude `--import` from the export-flag prepend, so it renders as its own mode `-Bi`. Everything else is unchanged.

Rendered `shelly backup utility` examples after the fix:

```
  -B                Shortcode
  -Be               Exports a declaritive list ...
  -Bi               Imports a previously exported backup ...
  -Bea <name>       File name without the .toml extension
  -Bed <directory>  Directory in which to write/read the backup
  -Bh               Show help for this command
```

## Testing

- Added a regression test in `help.zig` asserting the rendered backup help contains `-Bi` (and not `-Bei`) while `-Be`, `-Bea <name>`, and `-Bed <directory>` stay intact. It fails before this change and passes after.
- Verified the shortcode semantics behind the example: `-Bi` → `backup -i` (valid import), `-Be` → `backup -e` (valid export), `-Bei` → `backup -e -i` (contradictory, rejected).
- `zig fmt --check` is clean on the edited file.

Note: I ran the affected module's tests in isolation (the `help` module plus its transitive `spec`/`catalog` tests — 17 tests, all passing) because a full `zig build test` of `Shelly.Cli.Zig` requires the system `alpm` library via pkg-config, which is not installable in my sandbox. The change is confined to help-text example generation and touches no ALPM path.