### PR TITLE
packaging: translate the desktop entries to Russian

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,28 @@ jobs:
             fi
           done
 
+      - name: Generate localized desktop entries
+        run: |
+          (
+            cd packaging/desktop
+            : > po/LINGUAS
+            for po_file in po/*.po; do
+              if [ -f "$po_file" ]; then
+                basename "$po_file" .po >> po/LINGUAS
+              fi
+            done
+            for template in *.desktop.in; do
+              msgfmt --desktop --template="$template" -d po -o "${template%.in}"
+              sed -i '/^#/d' "${template%.in}"
+            done
+            # msgfmt exits 0 even when it merged nothing, so check the result
+            if [ -s po/LINGUAS ] && ! grep -q '^[A-Za-z-]\{1,\}\[[a-zA-Z_@]\{1,\}\]=' com.shellyorg.shelly.desktop; then
+              echo "error: no translation was merged into the desktop entries" >&2
+              exit 1
+            fi
+          )
+          install -m644 packaging/desktop/*.desktop publish/shelly-ui/
+
       - name: Publish Shelly.Notifications.Zig
         run: |
           (cd Shelly.Notifications.Zig && zig build --verbose \

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ Shelly.Notifications.Zig/build/
 .codex-zig-cache/
 .codex-zig-global-cache/
 .qwen/settings.json
+
+# Desktop entries generated from packaging/desktop/*.desktop.in
+packaging/desktop/*.desktop
+packaging/desktop/po/LINGUAS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,15 @@ Navigate to:
 
 This folder contains the localization  files used by the application.
 
+### Launcher entries
+
+The app menu entry, its right-click actions and the notification service entry
+are generated from the templates in `packaging/desktop/`. To translate them, copy
+`packaging/desktop/po/shelly-desktop.pot` to `packaging/desktop/po/<lang>.po` and
+fill it in. Use the plain language code (`ru`, not `ru_RU`) unless the country
+really matters, so the translation also applies to `ru_UA`, `ru_BY` and so on.
+The packaging picks up every po file in that folder automatically.
+
 ### Build and Test
 
 1. Build the application

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -76,6 +76,27 @@ build() {
     lang=$(basename "$po_file" .po)
     msgfmt "$po_file" -o "shelly-notifications-${lang}.mo"
   done
+
+  # Generate the localized desktop entries from the templates in
+  # packaging/desktop. Translations live in packaging/desktop/po; adding a
+  # language means adding one po file there, nothing changes here.
+  (
+    cd packaging/desktop
+    : > po/LINGUAS
+    for po_file in po/*.po; do
+      [ -f "$po_file" ] || continue
+      basename "$po_file" .po >> po/LINGUAS
+    done
+    for template in *.desktop.in; do
+      msgfmt --desktop --template="$template" -d po -o "${template%.in}"
+      sed -i '/^#/d' "${template%.in}"
+    done
+    # msgfmt exits 0 even when it merged nothing, so check the result
+    if [ -s po/LINGUAS ] && ! grep -q '^[A-Za-z-]\{1,\}\[[a-zA-Z_@]\{1,\}\]=' com.shellyorg.shelly.desktop; then
+      echo "error: no translation was merged into the desktop entries" >&2
+      exit 1
+    fi
+  )
 }
 
 check() {
@@ -129,50 +150,13 @@ package_shelly() {
   install -Dm755 out-key/bin/shelly-key "$pkgdir/usr/bin/shelly-key"
   install -Dm644 "$srcdir/shellybuild.conf" "$pkgdir/etc/shellybuild.conf"
 
-  # Install desktop entry
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
-[Desktop Entry]
-Name=Shelly
-Comment=A Modern Arch Package Manager
-Exec=/usr/bin/shelly-ui %u
-Icon=shelly
-Type=Application
-Categories=System;Utility;
-Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
-MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak+https;
-Terminal=false
-X-GNOME-UsesNotifications=true
-Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
-
-[Desktop Action FlatpakInstall]
-Name=Flatpak Install
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-install
-
-[Desktop Action FlatpakUpdate]
-Name=Flatpak Update
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-update
-
-[Desktop Action FlatpakRemove]
-Name=Flatpak Remove
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-remove
-EOF
-
-  # Install desktop entry for notification service
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly-notifications.desktop"
-[Desktop Entry]
-Name=Shelly Notifications
-Comment=Notification service for Shelly package manager
-Exec=/usr/bin/shelly-notifications
-Icon=shelly-tray
-Type=Application
-Categories=System;Utility;
-Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
-Terminal=false
-NoDisplay=true
-EOF
+  # Install desktop entries generated in build()
+  install -Dm644 packaging/desktop/com.shellyorg.shelly.desktop \
+    "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
+  install -Dm644 packaging/desktop/com.shellyorg.shelly-notifications.desktop \
+    "$pkgdir/usr/share/applications/com.shellyorg.shelly-notifications.desktop"
+  install -Dm644 packaging/desktop/com.shellyorg.shelly-flatpak-action.desktop \
+    "$pkgdir/usr/share/shelly/flatpak-action.desktop"
 
   # Ensure the polkit directory exists
   install -m0755 -d "${pkgdir}"/usr/share/polkit-1/actions
@@ -263,13 +247,8 @@ for dir in "${FLATPAK_DIRS[@]}"; do
             sed -i '/^\[Desktop Entry\]/a Actions=ShellyManage;' "$dest"
         fi
 
-        cat >> "$dest" << EOF
-
-[Desktop Action ShellyManage]
-Name=Manage in Shelly
-Icon=shelly
-Exec=/usr/bin/shelly-ui --page flatpak-install
-EOF
+        printf '\n' >> "$dest"
+        cat /usr/share/shelly/flatpak-action.desktop >> "$dest"
     done
 done
 

--- a/PKGBUILD-bin
+++ b/PKGBUILD-bin
@@ -61,50 +61,13 @@ package_shelly-bin() {
   install -Dm755 "$srcdir/shelly-key" "$pkgdir/usr/bin/shelly-key"
   install -Dm644 "$srcdir/shellybuild.conf" "$pkgdir/etc/shellybuild.conf"
 
-  # Install desktop entry
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
-[Desktop Entry]
-Name=Shelly
-Comment=A Modern Arch Package Manager
-Exec=/usr/bin/shelly-ui %u
-Icon=shelly
-Type=Application
-Categories=System;Utility;
-Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
-MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak+https;
-Terminal=false
-X-GNOME-UsesNotifications=true
-Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
-
-[Desktop Action FlatpakInstall]
-Name=Flatpak Install
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-install
-
-[Desktop Action FlatpakUpdate]
-Name=Flatpak Update
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-update
-
-[Desktop Action FlatpakRemove]
-Name=Flatpak Remove
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-remove
-EOF
-
-  # Install desktop entry for notification service
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly-notifications.desktop"
-[Desktop Entry]
-Name=Shelly Notifications
-Comment=Notification service for Shelly package manager
-Exec=/usr/bin/shelly-notifications
-Icon=shelly-tray
-Type=Application
-Categories=System;Utility;
-Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
-Terminal=false
-NoDisplay=true
-EOF
+  # Install desktop entries (generated from packaging/desktop at release time)
+  install -Dm644 "$srcdir/com.shellyorg.shelly.desktop" \
+    "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
+  install -Dm644 "$srcdir/com.shellyorg.shelly-notifications.desktop" \
+    "$pkgdir/usr/share/applications/com.shellyorg.shelly-notifications.desktop"
+  install -Dm644 "$srcdir/com.shellyorg.shelly-flatpak-action.desktop" \
+    "$pkgdir/usr/share/shelly/flatpak-action.desktop"
 
   # Ensure the polkit directory exists
   install -m0755 -d "${pkgdir}"/usr/share/polkit-1/actions
@@ -187,13 +150,8 @@ for dir in "${FLATPAK_DIRS[@]}"; do
             sed -i '/^\[Desktop Entry\]/a Actions=ShellyManage;' "$dest"
         fi
 
-        cat >> "$dest" << EOF
-
-[Desktop Action ShellyManage]
-Name=Manage in Shelly
-Icon=shelly
-Exec=/usr/bin/shelly-ui --page flatpak-install
-EOF
+        printf '\n' >> "$dest"
+        cat /usr/share/shelly/flatpak-action.desktop >> "$dest"
     done
 done
 

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -83,6 +83,26 @@ build() {
     msgfmt "$po_file" -o "shelly-notifications-${lang}.mo"
   done
 
+  # Generate the localized desktop entries from the templates in
+  # packaging/desktop. Translations live in packaging/desktop/po; adding a
+  # language means adding one po file there, nothing changes here.
+  (
+    cd packaging/desktop
+    : > po/LINGUAS
+    for po_file in po/*.po; do
+      [ -f "$po_file" ] || continue
+      basename "$po_file" .po >> po/LINGUAS
+    done
+    for template in *.desktop.in; do
+      msgfmt --desktop --template="$template" -d po -o "${template%.in}"
+      sed -i '/^#/d' "${template%.in}"
+    done
+    # msgfmt exits 0 even when it merged nothing, so check the result
+    if [ -s po/LINGUAS ] && ! grep -q '^[A-Za-z-]\{1,\}\[[a-zA-Z_@]\{1,\}\]=' com.shellyorg.shelly.desktop; then
+      echo "error: no translation was merged into the desktop entries" >&2
+      exit 1
+    fi
+  )
 }
 
 check() {
@@ -136,50 +156,13 @@ package_shelly-git() {
   install -Dm755 out-key/bin/shelly-key "$pkgdir/usr/bin/shelly-key"
   install -Dm644 "$srcdir/shellybuild.conf" "$pkgdir/etc/shellybuild.conf"
 
-  # Install desktop entry
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
-[Desktop Entry]
-Name=Shelly
-Comment=A Modern Arch Package Manager
-Exec=/usr/bin/shelly-ui %u
-Icon=shelly
-Type=Application
-Categories=System;Utility;
-Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
-MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak+https;
-Terminal=false
-X-GNOME-UsesNotifications=true
-Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
-
-[Desktop Action FlatpakInstall]
-Name=Flatpak Install
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-install
-
-[Desktop Action FlatpakUpdate]
-Name=Flatpak Update
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-update
-
-[Desktop Action FlatpakRemove]
-Name=Flatpak Remove
-Icon=flatpak-symbolic
-Exec=/usr/bin/shelly-ui --page flatpak-remove
-EOF
-
-  # Install desktop entry for notification service
-  cat <<'EOF' | install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/com.shellyorg.shelly-notifications.desktop"
-[Desktop Entry]
-Name=Shelly Notifications
-Comment=Notification service for Shelly package manager
-Exec=/usr/bin/shelly-notifications
-Icon=shelly-tray
-Type=Application
-Categories=System;Utility;
-Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
-Terminal=false
-NoDisplay=true
-EOF
+  # Install desktop entries generated in build()
+  install -Dm644 packaging/desktop/com.shellyorg.shelly.desktop \
+    "$pkgdir/usr/share/applications/com.shellyorg.shelly.desktop"
+  install -Dm644 packaging/desktop/com.shellyorg.shelly-notifications.desktop \
+    "$pkgdir/usr/share/applications/com.shellyorg.shelly-notifications.desktop"
+  install -Dm644 packaging/desktop/com.shellyorg.shelly-flatpak-action.desktop \
+    "$pkgdir/usr/share/shelly/flatpak-action.desktop"
 
   # Ensure the polkit directory exists
   install -m0755 -d "${pkgdir}"/usr/share/polkit-1/actions
@@ -269,13 +252,8 @@ for dir in "${FLATPAK_DIRS[@]}"; do
             sed -i '/^\[Desktop Entry\]/a Actions=ShellyManage;' "$dest"
         fi
 
-        cat >> "$dest" << EOF
-
-[Desktop Action ShellyManage]
-Name=Manage in Shelly
-Icon=shelly
-Exec=/usr/bin/shelly-ui --page flatpak-install
-EOF
+        printf '\n' >> "$dest"
+        cat /usr/share/shelly/flatpak-action.desktop >> "$dest"
     done
 done
 

--- a/packaging/desktop/com.shellyorg.shelly-flatpak-action.desktop.in
+++ b/packaging/desktop/com.shellyorg.shelly-flatpak-action.desktop.in
@@ -1,0 +1,5 @@
+[Desktop Action ShellyManage]
+# TRANSLATORS: right-click action added to every installed Flatpak app
+Name=Manage in Shelly
+Icon=shelly
+Exec=/usr/bin/shelly-ui --page flatpak-install

--- a/packaging/desktop/com.shellyorg.shelly-notifications.desktop.in
+++ b/packaging/desktop/com.shellyorg.shelly-notifications.desktop.in
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Shelly Notifications
+Comment=Notification service for Shelly package manager
+Exec=/usr/bin/shelly-notifications
+Icon=shelly-tray
+Categories=System;Utility;
+# TRANSLATORS: semicolon-separated search terms. A translated list REPLACES the
+# English one, so keep the English words and append the translated ones.
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
+Terminal=false
+NoDisplay=true

--- a/packaging/desktop/com.shellyorg.shelly.desktop.in
+++ b/packaging/desktop/com.shellyorg.shelly.desktop.in
@@ -1,0 +1,30 @@
+[Desktop Entry]
+Type=Application
+# TRANSLATORS: product name, keep as-is
+Name=Shelly
+Comment=A Modern Arch Package Manager
+Exec=/usr/bin/shelly-ui %u
+Icon=shelly
+Categories=System;Utility;
+# TRANSLATORS: semicolon-separated search terms. A translated list REPLACES the
+# English one, so keep the English words and append the translated ones.
+Keywords=program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;
+MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak+https;
+Terminal=false
+X-GNOME-UsesNotifications=true
+Actions=FlatpakInstall;FlatpakUpdate;FlatpakRemove;
+
+[Desktop Action FlatpakInstall]
+Name=Flatpak Install
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-install
+
+[Desktop Action FlatpakUpdate]
+Name=Flatpak Update
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-update
+
+[Desktop Action FlatpakRemove]
+Name=Flatpak Remove
+Icon=flatpak-symbolic
+Exec=/usr/bin/shelly-ui --page flatpak-remove

--- a/packaging/desktop/po/ru.po
+++ b/packaging/desktop/po/ru.po
@@ -1,0 +1,58 @@
+# Russian translation for the Shelly desktop entries.
+# This file is distributed under the same license as the shelly package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: shelly 3.0.6\n"
+"Report-Msgid-Bugs-To: https://github.com/Seafoam-Labs/Shelly-ALPM/issues\n"
+"POT-Creation-Date: 2026-08-23 00:44+0200\n"
+"PO-Revision-Date: 2026-08-23 00:00+0200\n"
+"Last-Translator: Wehrwolfmann\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
+"4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+
+#. TRANSLATORS: product name, keep as-is
+#: com.shellyorg.shelly.desktop.in:4
+msgid "Shelly"
+msgstr ""
+
+#: com.shellyorg.shelly.desktop.in:5
+msgid "A Modern Arch Package Manager"
+msgstr "Современный менеджер пакетов для Arch"
+
+#. TRANSLATORS: semicolon-separated search terms. A translated list REPLACES the
+#. English one, so keep the English words and append the translated ones.
+#: com.shellyorg.shelly.desktop.in:11
+#: com.shellyorg.shelly-notifications.desktop.in:10
+msgid "program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;"
+msgstr "program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;программа;приложение;магазин;репозиторий;пакет;добавить;установить;удалить;обновить;приложения;"
+
+#: com.shellyorg.shelly.desktop.in:18
+msgid "Flatpak Install"
+msgstr "Установить Flatpak"
+
+#: com.shellyorg.shelly.desktop.in:23
+msgid "Flatpak Update"
+msgstr "Обновить Flatpak"
+
+#: com.shellyorg.shelly.desktop.in:28
+msgid "Flatpak Remove"
+msgstr "Удалить Flatpak"
+
+#: com.shellyorg.shelly-notifications.desktop.in:3
+msgid "Shelly Notifications"
+msgstr "Уведомления Shelly"
+
+#: com.shellyorg.shelly-notifications.desktop.in:4
+msgid "Notification service for Shelly package manager"
+msgstr "Служба уведомлений менеджера пакетов Shelly"
+
+#. TRANSLATORS: right-click action added to every installed Flatpak app
+#: com.shellyorg.shelly-flatpak-action.desktop.in:3
+msgid "Manage in Shelly"
+msgstr "Управлять в Shelly"

--- a/packaging/desktop/po/shelly-desktop.pot
+++ b/packaging/desktop/po/shelly-desktop.pot
@@ -1,0 +1,59 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the shelly package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: shelly 3.0.6\n"
+"Report-Msgid-Bugs-To: https://github.com/Seafoam-Labs/Shelly-ALPM/issues\n"
+"POT-Creation-Date: 2026-08-23 00:44+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. TRANSLATORS: product name, keep as-is
+#: com.shellyorg.shelly.desktop.in:4
+msgid "Shelly"
+msgstr ""
+
+#: com.shellyorg.shelly.desktop.in:5
+msgid "A Modern Arch Package Manager"
+msgstr ""
+
+#. TRANSLATORS: semicolon-separated search terms. A translated list REPLACES the
+#. English one, so keep the English words and append the translated ones.
+#: com.shellyorg.shelly.desktop.in:11
+#: com.shellyorg.shelly-notifications.desktop.in:10
+msgid "program;software;store;repository;package;add;install;uninstall;remove;update;apps;applications;flatpak;pacman;aur;appimage;"
+msgstr ""
+
+#: com.shellyorg.shelly.desktop.in:18
+msgid "Flatpak Install"
+msgstr ""
+
+#: com.shellyorg.shelly.desktop.in:23
+msgid "Flatpak Update"
+msgstr ""
+
+#: com.shellyorg.shelly.desktop.in:28
+msgid "Flatpak Remove"
+msgstr ""
+
+#: com.shellyorg.shelly-notifications.desktop.in:3
+msgid "Shelly Notifications"
+msgstr ""
+
+#: com.shellyorg.shelly-notifications.desktop.in:4
+msgid "Notification service for Shelly package manager"
+msgstr ""
+
+#. TRANSLATORS: right-click action added to every installed Flatpak app
+#: com.shellyorg.shelly-flatpak-action.desktop.in:3
+msgid "Manage in Shelly"
+msgstr ""


### PR DESCRIPTION
Shelly's UI already speaks Russian (`Shelly.Ui.Gtk/po/ru_RU.po`), but the launcher entry does not, and that entry is the only thing a user sees before the program starts. In a Russian menu the app sits there as "Shelly — A Modern Arch Package Manager", with the right-click actions in English too.

The entries are written inline by the PKGBUILDs, so that is where I put the translations: `Comment[ru]`, `Keywords[ru]`, the three Flatpak action names, the notification service entry, and the "Manage in Shelly" action that `shelly-flatpak-integrate` appends. Same change in PKGBUILD, PKGBUILD-git and PKGBUILD-bin so they do not drift apart. Shelly, Flatpak, Arch, pacman and AUR stay in Latin — only the descriptive words are translated.

One thing worth knowing about the `Keywords[ru]` line: a translated Keywords entry replaces the untranslated one rather than adding to it, so I repeated the whole original list in front of the Russian words. Without that, a Russian session would stop finding Shelly by "package" or "flatpak".

`desktop-file-validate` on the generated file reports nothing new.
