### PR TITLE
Adding .crate suffix to isExtractableArchive()

### DIFF
--- a/Shelly.PackageManager/src/aur/builder/source_spec.zig
+++ b/Shelly.PackageManager/src/aur/builder/source_spec.zig
@@ -222,7 +222,7 @@ pub fn containsString(values: []const []const u8, needle: []const u8) bool {
 
 pub fn isExtractableArchive(name: []const u8) bool {
     const suffixes = [_][]const u8{
-        ".tar", ".tar.gz", ".tgz", ".tar.zst", ".tar.xz", ".txz", ".tar.bz2", ".tbz", ".tbz2", ".zip", ".vsix", ".deb",
+        ".tar", ".tar.gz", ".tgz", ".tar.zst", ".tar.xz", ".txz", ".tar.bz2", ".tbz", ".tbz2", ".zip", ".vsix", ".deb", ".crate",
     };
     for (suffixes) |suffix| if (std.ascii.endsWithIgnoreCase(name, suffix)) return true;
     return false;


### PR DESCRIPTION
This PR introduces the .crate suffix to isExtractableArchive(), allowing for .crate files to be extracted.