### PR TITLE
fix(welcome): skip reinstalling support packages that are already installed

### DIFF
--- a/Shelly.Ui.Gtk/src/pages/welcome.zig
+++ b/Shelly.Ui.Gtk/src/pages/welcome.zig
@@ -11,6 +11,7 @@ const AurWarningDialog = @import("../dialog/page/aur_warning.zig").AurWarningDia
 const ShellyWindow = @import("../shelly_window.zig").ShellyWindow;
 const runtime = @import("../services/runtime.zig");
 const ShellyCommands = @import("../services/shelly_operation.zig").ShellyCommands;
+const ShellyCli = @import("../services/shelly_cli.zig").ShellyCli;
 const support_packages = @import("../services/support_packages.zig");
 const ShellyConfig = @import("../models/shelly_config.zig").ShellyConfig;
 const NavMode = @import("../models/shelly_config.zig").NavMode;
@@ -297,12 +298,7 @@ pub const WelcomePage = extern struct {
 
     fn startSupportInstall(window: *ShellyWindow, flatpak: bool, appimage: bool) void {
         var package_buffer: [2][]const u8 = undefined;
-        const packages = support_packages.selectedDependencies(&package_buffer, flatpak, appimage);
-        const argv = ShellyCommands.install(std.heap.c_allocator, packages) catch {
-            window.hideLockout();
-            return;
-        };
-        defer std.heap.c_allocator.free(argv);
+        const packages = needsInstall(&package_buffer, flatpak, appimage);
 
         const ctx = std.heap.c_allocator.create(SupportInstallContext) catch {
             window.hideLockout();
@@ -314,6 +310,19 @@ pub const WelcomePage = extern struct {
             .appimage = appimage,
         };
 
+        if (packages.len == 0) {
+            // All support packages already installed; skip to the next stage.
+            on_support_install_complete(ctx, true);
+            return;
+        }
+
+        const argv = ShellyCommands.install(std.heap.c_allocator, packages) catch {
+            std.heap.c_allocator.destroy(ctx);
+            window.hideLockout();
+            return;
+        };
+        defer std.heap.c_allocator.free(argv);
+
         window.startTransaction(.{
             .title = supportInstallTitle(flatpak, appimage),
             .argv = argv,
@@ -322,6 +331,25 @@ pub const WelcomePage = extern struct {
             .on_complete = &on_support_install_complete,
             .ctx = ctx,
         });
+    }
+
+    /// Returns the subset of support packages that are not yet installed.
+    /// Falls back to the full selected list if the installed-package query fails.
+    fn needsInstall(buffer: *[2][]const u8, flatpak: bool, appimage: bool) []const []const u8 {
+        const cli = ShellyCli{ .allocator = std.heap.c_allocator, .io = runtime.io };
+        const parsed = cli.get_installed_packages() catch {
+            return support_packages.selectedDependencies(buffer, flatpak, appimage);
+        };
+        defer parsed.deinit();
+        var names: [256][]const u8 = undefined;
+        var n: usize = 0;
+        for (parsed.value) |pkg| {
+            if (n < names.len) {
+                names[n] = pkg.Name;
+                n += 1;
+            }
+        }
+        return support_packages.uninstalledDependencies(buffer, flatpak, appimage, names[0..n]);
     }
 
     fn on_support_install_complete(raw_ctx: *anyopaque, success: bool) void {

--- a/Shelly.Ui.Gtk/src/services/support_packages.zig
+++ b/Shelly.Ui.Gtk/src/services/support_packages.zig
@@ -41,6 +41,33 @@ pub fn selectedDependencies(
     return buffer[0..len];
 }
 
+/// Returns the subset of `selectedDependencies` whose names are absent from
+/// `installed_names`, so the caller can skip a redundant reinstall.
+pub fn uninstalledDependencies(
+    buffer: *[2][]const u8,
+    flatpak: bool,
+    appimage: bool,
+    installed_names: []const []const u8,
+) []const []const u8 {
+    const candidates: [2][]const []const u8 = .{
+        if (flatpak) &flatpak_dependencies else &.{},
+        if (appimage) &appimage_dependencies else &.{},
+    };
+    var len: usize = 0;
+    for (candidates) |list| {
+        for (list) |pkg| {
+            const already = for (installed_names) |n| {
+                if (std.mem.eql(u8, n, pkg)) break true;
+            } else false;
+            if (!already) {
+                buffer[len] = pkg;
+                len += 1;
+            }
+        }
+    }
+    return buffer[0..len];
+}
+
 test "selected support dependencies combine Flatpak and AppImage requirements" {
     var buffer: [2][]const u8 = undefined;
     const packages = selectedDependencies(&buffer, true, true);
@@ -65,6 +92,30 @@ test "selected support dependencies include only requested features" {
         selectedDependencies(&buffer, false, true),
     );
     try std.testing.expectEqual(@as(usize, 0), selectedDependencies(&buffer, false, false).len);
+}
+
+test "uninstalled dependencies excludes packages already present" {
+    var buffer: [2][]const u8 = undefined;
+
+    // flatpak already installed → only fuse2 remains
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{"fuse2"},
+        uninstalledDependencies(&buffer, true, true, &.{"flatpak"}),
+    );
+
+    // both already installed → nothing to install
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        uninstalledDependencies(&buffer, true, true, &.{ "flatpak", "fuse2" }).len,
+    );
+
+    // nothing installed → full list returned
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "flatpak", "fuse2" },
+        uninstalledDependencies(&buffer, true, true, &.{}),
+    );
 }
 
 test "Flatpak backend remains a separate configured package" {


### PR DESCRIPTION
Fixes #1770.

## Problem

When the welcome wizard's support-install step runs, it calls `ShellyCommands.install` unconditionally with every requested support package (`flatpak`, `fuse2`), even when one or both are already present on the system. `pacman -S <pkg>` on an already-installed package triggers a full reinstall, which is unexpected and wastes time.

## Fix

Two changes:

**`Shelly.Ui.Gtk/src/services/support_packages.zig`**

Adds `uninstalledDependencies`, which accepts the caller-supplied list of already-installed package names and returns only the subset not yet present. Three new unit tests cover the filter logic.

**`Shelly.Ui.Gtk/src/pages/welcome.zig`**

Adds a `needsInstall` helper that calls `ShellyCli.get_installed_packages` (a quick local ALPM read via the shelly binary) and delegates to `uninstalledDependencies`. If the query fails for any reason the helper falls back to the original full list, so the change is never worse than before.

`startSupportInstall` now calls `needsInstall` instead of `selectedDependencies`. When the returned slice is empty (all packages already installed), it allocates the `SupportInstallContext` and calls `on_support_install_complete` directly with `success = true`, advancing to the flatpak-backend stage if needed — no code duplication.

## Notes

- The `get_installed_packages` call runs synchronously on the GTK main thread. For the welcome wizard (a one-time first-run flow triggered by a user click) the latency is negligible; no threading change was needed.
- The fix does not touch the flatpak-backend install stage — that path already handles the case where flatpak the binary is present but a backend package is absent.